### PR TITLE
pull base images (from) before building

### DIFF
--- a/src/main/java/org/jolokia/docker/maven/BuildMojo.java
+++ b/src/main/java/org/jolokia/docker/maven/BuildMojo.java
@@ -61,6 +61,10 @@ public class BuildMojo extends AbstractDockerMojo {
 
     private void buildImage(ImageConfiguration imageConfig, DockerAccess dockerAccess)
             throws DockerAccessException, MojoExecutionException {
+        String fromName = imageConfig.getBuildConfiguration().getFrom();
+        info("Pulling base image " + fromName);
+        dockerAccess.pullImage(fromName, prepareAuthConfig(fromName));
+
         MojoParameters params =  new MojoParameters(session, project, archive, mavenFileFilter);
         File dockerArchive = dockerArchiveCreator.create(params, imageConfig.getBuildConfiguration());
         String imageName = getImageName(imageConfig.getName());

--- a/src/main/java/org/jolokia/docker/maven/access/DockerAccessWithHttpClient.java
+++ b/src/main/java/org/jolokia/docker/maven/access/DockerAccessWithHttpClient.java
@@ -208,12 +208,14 @@ public class DockerAccessWithHttpClient implements DockerAccess {
 
     /** {@inheritDoc} */
     @Override
-    public void pullImage(String image,AuthConfig authConfig) throws DockerAccessException {
+    public void pullImage(String image, AuthConfig authConfig) throws DockerAccessException {
         ImageName name = new ImageName(image);
-        String pullUrl = baseUrl + "/images/create?fromImage=" + encode(name.getRepository());
+        String pullUrl = baseUrl + "/images/create?fromImage=" + encode(name.getRepositoryWithRegistry());
         pullUrl = addTag(pullUrl, name);
+        // adding registry parameter seems to have no effect, added it to the fromName instead
         pullUrl = addRegistry(pullUrl, name);
-        pullOrPushImage(image, pullUrl, "pulling", authConfig);
+        // do not add the authConfig if the fromImage is from the public registry
+        pullOrPushImage(image, pullUrl, "pulling", name.hasRegistry() ? authConfig : null);
     }
 
     /** {@inheritDoc} */
@@ -222,7 +224,7 @@ public class DockerAccessWithHttpClient implements DockerAccess {
         ImageName name = new ImageName(image);
         String pushUrl = baseUrl + "/images/" + encode(name.getRepositoryWithRegistry()) + "/push";
         pushUrl = addTag(pushUrl, name);
-            pullOrPushImage(image, pushUrl, "pushing", authConfig);
+        pullOrPushImage(image, pushUrl, "pushing", authConfig);
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
Currently I did not manage to build an image from a base image when the base image is not available locally and the private registry requires authentication.
For example building my.registry.com/example:latest from my.registry.com/dependant:latest.

The problem is that the BuildMojo is not adding the authConfig to the request. I tried adding it but to no effect on the docker daemon side. Thus now the "from" image is being pulled before the actual image is being build.
After that I had the problem, that during pull the "registry" parameter was not being honored by the docker daemon, prefixing the image name with the registry name works however.