### PR TITLE
fix for stopping containers using the 'latest' tag

### DIFF
--- a/src/main/java/org/jolokia/docker/maven/access/DockerAccessWithHttpClient.java
+++ b/src/main/java/org/jolokia/docker/maven/access/DockerAccessWithHttpClient.java
@@ -162,6 +162,10 @@ public class DockerAccessWithHttpClient implements DockerAccess {
     }
 
     private List<String> getContainerIds(String image,boolean onlyLatest) throws DockerAccessException {
+        if (!image.contains(":")) {
+            image = image + ":latest";
+        }
+        
         List<String> ret = new ArrayList<>();
         HttpUriRequest req = newGet(baseUrl + "/containers/json?limit=100");
         HttpResponse resp = request(req);


### PR DESCRIPTION
containers tagged with `latest` are not properly handled by the `docker:stop` goal.

Signed-off-by: Jae Gangemi <jgangemi@gmail.com>