### PR TITLE
fix #76 #77

### DIFF
--- a/src/main/java/org/jolokia/docker/maven/StartMojo.java
+++ b/src/main/java/org/jolokia/docker/maven/StartMojo.java
@@ -31,7 +31,7 @@ import org.jolokia.docker.maven.util.*;
 public class StartMojo extends AbstractDockerMojo {
 
     /**
-     * @parameter property = "docker.autoPull" defaultValue = "true"
+     * @parameter property = "docker.autoPull" default-value = "true"
      */
     private boolean autoPull;
 

--- a/src/main/java/org/jolokia/docker/maven/access/DockerAccess.java
+++ b/src/main/java/org/jolokia/docker/maven/access/DockerAccess.java
@@ -18,7 +18,7 @@ public interface DockerAccess {
     /**
      * Check whether the given Image is locally available.
      *
-     * @param image name of image to check
+     * @param image name of image to check, the image can contain a tag, otherwise 'latest' will be appended
      * @return true if the image is locally available or false if it must be pulled.
      * @throws DockerAccessException in case of an request error
      */


### PR DESCRIPTION
* allows autoPull to be specified on build
* make sure DockerAccess.hasImage() respects the tag and thus finds the correct image, before it only looked for the image name (repository) and this failed if the correct tag was not present
* BuildMojo now always does a manual pull of the 'fromImage' if it does not already exist or autoPull is enabled. This is necessary because the automatic pull that docker does itself during the create fails to authenticate against a private registry.