### PR TITLE
fixed plugin can not find assembly descriptor

### DIFF
--- a/src/main/java/org/jolokia/docker/maven/assembly/DockerAssemblyConfigurationSource.java
+++ b/src/main/java/org/jolokia/docker/maven/assembly/DockerAssemblyConfigurationSource.java
@@ -32,9 +32,9 @@ public class DockerAssemblyConfigurationSource implements AssemblerConfiguration
     @Override
     public String[] getDescriptors() {
         String descriptor = assemblyConfig.getDescriptor();
-        
+
         if (descriptor != null) {
-            return new String[] { EnvUtil.prepareAbsolutePath(params.getSourceDirectory(),descriptor).getAbsolutePath() };
+            return new String[] { EnvUtil.prepareAbsolutePath(params, descriptor).getAbsolutePath() };
         } else {
             return new String[0];
         }

--- a/src/main/java/org/jolokia/docker/maven/assembly/DockerAssemblyManager.java
+++ b/src/main/java/org/jolokia/docker/maven/assembly/DockerAssemblyManager.java
@@ -64,12 +64,12 @@ public class DockerAssemblyManager {
                 return createTarball(source,null);
             }
         } catch (IOException e) {
-            throw new MojoExecutionException(String.format("Cannot create Dockerfile in %s", outputDir, e));
+            throw new MojoExecutionException(String.format("Cannot create Dockerfile in %s", outputDir), e);
         }
     }
 
     private File validateDockerDir(MojoParameters params, String dockerFileDir) throws MojoExecutionException {
-        File dockerDir = EnvUtil.prepareAbsolutePath(params.getSourceDirectory(), dockerFileDir);
+        File dockerDir = EnvUtil.prepareAbsolutePath(params, dockerFileDir);
         if (! new File(dockerDir,"Dockerfile").exists()) {
             throw new MojoExecutionException("Specified dockerFileDir " + dockerFileDir +
                                              " doesn't contain a 'Dockerfile'");

--- a/src/main/java/org/jolokia/docker/maven/util/EnvUtil.java
+++ b/src/main/java/org/jolokia/docker/maven/util/EnvUtil.java
@@ -150,11 +150,11 @@ public class EnvUtil {
         return System.getenv("DOCKER_REGISTRY");
     }
 
-    public static File prepareAbsolutePath(String parent,String path) {
+    public static File prepareAbsolutePath(MojoParameters params, String path) {
         File file = new File(path);
         if (file.isAbsolute()) {
             return file;
         }
-        return new File(parent + File.separator + path);
+        return new File(new File(params.getProject().getBasedir(), params.getSourceDirectory()), path);
     }
 }

--- a/src/test/java/org/jolokia/docker/maven/assembly/DockerAssemblyConfigurationSourceTest.java
+++ b/src/test/java/org/jolokia/docker/maven/assembly/DockerAssemblyConfigurationSourceTest.java
@@ -2,6 +2,7 @@ package org.jolokia.docker.maven.assembly;
 
 import java.io.File;
 
+import org.apache.maven.project.MavenProject;
 import org.jolokia.docker.maven.config.AssemblyConfiguration;
 import org.jolokia.docker.maven.util.EnvUtil;
 import org.jolokia.docker.maven.util.MojoParameters;
@@ -26,12 +27,18 @@ public class DockerAssemblyConfigurationSourceTest {
 
     @Test
     public void testCreateSourceAbsolute() {
-        testCreateSource(new MojoParameters(null, null, null, null, "/src/docker", "/output/docker"));
+        testCreateSource(buildParameters("/src/docker", "/output/docker"));
     }
 
     @Test
     public void testCreateSourceRelative() {
-        testCreateSource(new MojoParameters(null, null, null, null, "src/docker", "output/docker"));
+        testCreateSource(buildParameters("src/docker", "output/docker"));
+    }
+
+    private MojoParameters buildParameters(String sourceDir, String outputDir) {
+        MavenProject mavenProject = new MavenProject();
+        mavenProject.setFile(new File("."));
+        return new MojoParameters(null, mavenProject, null, null, sourceDir, outputDir);
     }
 
     private void testCreateSource(MojoParameters params) {
@@ -41,7 +48,7 @@ public class DockerAssemblyConfigurationSourceTest {
         String[] descriptorRefs = source.getDescriptorReferences();
 
         assertEquals(1, descriptors.length);
-        assertEquals(EnvUtil.prepareAbsolutePath(params.getSourceDirectory(),"assembly.xml").getAbsolutePath(), descriptors[0]);
+        assertEquals(EnvUtil.prepareAbsolutePath(params, "assembly.xml").getAbsolutePath(), descriptors[0]);
 
         assertEquals(1, descriptorRefs.length);
         assertEquals("project", descriptorRefs[0]);


### PR DESCRIPTION
The plugin could not find the assembly.xml file in the default source directory in multi-module maven projects.
It works if docker:build is executed from the sub-module but not if execute from the parent module.
When building the absolute path to the assembly.xml or Dockerfile the project baseDir is now respected.