### PR TITLE
allow hostnames to be specified in port configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Flattr](http://api.flattr.com/button/flattr-badge-large.png)](http://flattr.com/thing/73919/Jolokia-JMX-on-Capsaicin)
 
 This is a Maven plugin for managing Docker images and containers for your builds.
-The current version ist **0.11.0** and works with Maven 3.2.1 and Docker 1.3.0 or later.
+The current version ist **0.11.1** and works with Maven 3.2.1 and Docker 1.3.0 or later.
 
 The current Docker API version used is `v1.15` (which is the minimal required API version).
 See the **[User Manual](doc/manual.md)** for details on how to override this value for new

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,5 +1,8 @@
 # ChangeLog
 
+* **0.11.2**
+  - Allow hostnames to be used in port bindings
+
 * **0.11.1**
   - Add support for binding UDP ports (#83)
   - "Entrypoint" supports now arguments (#84)

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -485,6 +485,15 @@ address on docker host.
 </ports>
 ```
 
+As a convienence, a hostname pointing to the docker host may also
+be specified. The container will fail to start if the hostname resolves
+to an ip address of something other then the docker host.
+
+```
+<ports>
+  <port>example.com:80:80</port>
+</ports>
+
 Another useful configuration option is `portPropertyFile` with which a
 file can be specified to which the real port mapping is written after
 all dynamic ports has been resolved. The keys of this property file

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.jolokia</groupId>
   <artifactId>docker-maven-plugin</artifactId>
-  <version>0.11.1-SNAPSHOT</version>
+  <version>0.11.1</version>
   <packaging>maven-plugin</packaging>
 
   <name>maven-docker-plugin</name>
@@ -264,7 +264,7 @@
   <scm>
     <connection>scm:git:git://github.com/rhuss/docker-maven-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/rhuss/docker-maven-plugin.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v0.11.1</tag>
     <url>git://github.com/rhuss/docker-maven-plugin.git</url>
   </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.jolokia</groupId>
   <artifactId>docker-maven-plugin</artifactId>
-  <version>0.11.1</version>
+  <version>0.11.2-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>maven-docker-plugin</name>
@@ -264,7 +264,7 @@
   <scm>
     <connection>scm:git:git://github.com/rhuss/docker-maven-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/rhuss/docker-maven-plugin.git</developerConnection>
-    <tag>v0.11.1</tag>
+    <tag>HEAD</tag>
     <url>git://github.com/rhuss/docker-maven-plugin.git</url>
   </scm>
 

--- a/samples/cargo-jolokia-demo/pom.xml
+++ b/samples/cargo-jolokia-demo/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>org.jolokia</groupId>
   <artifactId>docker-jolokia-demo</artifactId>
-  <version>0.11.0</version>
+  <version>0.11.1</version>
 
   <url>http://www.jolokia.org</url>
 

--- a/samples/data-jolokia-demo/pom.xml
+++ b/samples/data-jolokia-demo/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>org.jolokia</groupId>
   <artifactId>docker-jolokia-demo</artifactId>
-  <version>0.11.1-SNAPSHOT</version>
+  <version>0.11.1</version>
 
   <url>http://www.jolokia.org</url>
 

--- a/src/main/java/org/jolokia/docker/maven/access/PortMapping.java
+++ b/src/main/java/org/jolokia/docker/maven/access/PortMapping.java
@@ -1,5 +1,7 @@
 package org.jolokia.docker.maven.access;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -178,7 +180,12 @@ public class PortMapping {
 		
 		if (bindToHost != null) {
 			// the container port can never be null, so use that as the key
-			bindToHostMap.put(containerPortSpec, bindToHost);
+		    try {
+		        String ipAddress = InetAddress.getByName(bindToHost).getHostAddress();
+		        bindToHostMap.put(containerPortSpec, ipAddress);
+		    } catch (UnknownHostException e) {
+		        throw new IllegalArgumentException("bind host [" + bindToHost + "] cannot be resolved");
+		    }
 		}
 		
 		containerPortsMap.put(containerPortSpec, hostPort);

--- a/src/test/java/org/jolokia/docker/maven/access/PortMappingTest.java
+++ b/src/test/java/org/jolokia/docker/maven/access/PortMappingTest.java
@@ -87,7 +87,7 @@ public class PortMappingTest {
         assertTrue(mapping.getBindToHostMap().values().contains("127.0.0.1"));
     }
     
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void testInvalidHostname() {
         createPortMapping("does-not-exist.pvt:80:80");
     }

--- a/src/test/java/org/jolokia/docker/maven/access/PortMappingTest.java
+++ b/src/test/java/org/jolokia/docker/maven/access/PortMappingTest.java
@@ -81,6 +81,17 @@ public class PortMappingTest {
                                 "http://localhost:50000/", "http://localhost:${jolokia.port}/");
     }
 
+    @Test
+    public void testValidHostname() {
+        PortMapping mapping = createPortMapping("localhost:80:80");
+        assertTrue(mapping.getBindToHostMap().values().contains("127.0.0.1"));
+    }
+    
+    @Test
+    public void testInvalidHostname() {
+        createPortMapping("does-not-exist.pvt:80:80");
+    }
+    
     @Test(expected = IllegalArgumentException.class)
     public void invalidMapping() throws MojoExecutionException {
         createPortMapping("bla");


### PR DESCRIPTION
this lets me manage manage bind hosts in different environments by way of `/etc/hosts` / dns instead of overriding maven properties.

docker won't bind to the address if it's not on the host, so specifying an invalid host name is the same as giving an incorrect ip.