### PR TITLE
Fixes for two JUnit tests on Windows

### DIFF
--- a/src/test/java/org/jolokia/docker/maven/assembly/DockerAssemblyConfigurationSourceTest.java
+++ b/src/test/java/org/jolokia/docker/maven/assembly/DockerAssemblyConfigurationSourceTest.java
@@ -64,7 +64,7 @@ public class DockerAssemblyConfigurationSourceTest {
 
         assertFalse(source.isIgnorePermissions());
 
-        String outputDir = params.getOutputDirectory();
+        String outputDir = new File(params.getOutputDirectory()).toString();
         assertTrue(containsOutputDir(outputDir, source.getOutputDirectory().toString()));
         assertTrue(containsOutputDir(outputDir, source.getWorkingDirectory().toString()));
         assertTrue(containsOutputDir(outputDir, source.getTemporaryRootDirectory().toString()));

--- a/src/test/java/org/jolokia/docker/maven/assembly/DockerFileBuilderTest.java
+++ b/src/test/java/org/jolokia/docker/maven/assembly/DockerFileBuilderTest.java
@@ -30,15 +30,19 @@ public class DockerFileBuilderTest {
                         .volumes(Arrays.asList("/vol1"));
 
         String expected = loadFile("docker/Dockerfile.test");
-        assertEquals(expected, builder.content());
+        assertEquals(expected, stripCR(builder.content()));
     }
 
     @Test
     public void testNoRootExport() {
         assertFalse(new DockerFileBuilder().add("/src", "/dest").basedir("/").content().contains("VOLUME"));
     }
+    
+    private String stripCR(String input){
+    	return input.replaceAll("\r", "");
+    }
 
     private String loadFile(String fileName) throws IOException {
-        return IOUtils.toString(getClass().getClassLoader().getResource(fileName));
+        return stripCR(IOUtils.toString(getClass().getClassLoader().getResource(fileName)));
     }
 }


### PR DESCRIPTION
Fixed two JUnit-test that were failing on Windows due to a difference in path separator chars (was using "/", was expecting "\"). It is now platform independent.