### PR TITLE
allow easy overriding of project artifact name when using pre-packaged descriptors

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -3,6 +3,8 @@
 * **0.11.2**
   - Fix maven parse error when specifying restart policy (#99)
   - Allow hostnames to be used in port bindings
+  - Allow `${project.build.finalName}` to be overridden when using a pre-packged assembly descriptor
+    for artifacts (#111)
 
 * **0.11.1**
   - Add support for binding UDP ports (#83)

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -343,6 +343,23 @@ Another container can now connect to the volume an 'mount' the
 into `/maven` and copy over everything to `/opt/tomcat/webapps` before
 starting Tomcat.
 
+If you are using the `artifact` or `artifact-with-dependencies` descriptor, it is
+possible to change the name of the final build artifact with the following:
+
+```xml
+<build>
+  <finalName>your-desired-final-name</build>
+  ...
+</build>
+```
+
+Please note, based upon the following documentation listed [here](http://maven.apache.org/pom.html#BaseBuild_Element),
+there is no guarentee the plugin creating your artifact will honor it in which case you will need to use a custom
+descriptor like above to achieve the desired naming.
+
+At the time of this writing, the `jar` and `war` plugins properly honor the usage of `finalName`.
+
+
 #### `docker:start`
 
 Creates and starts docker containers. This goals evaluates

--- a/src/main/resources/assemblies/artifact-with-dependencies.xml
+++ b/src/main/resources/assemblies/artifact-with-dependencies.xml
@@ -6,6 +6,13 @@
   <dependencySets>
     <dependencySet>
       <useProjectArtifact>true</useProjectArtifact>
+      <includes>
+        <include>${project.groupId}:${project.artifactId}</include>
+      </includes>
+      <outputFileNameMapping>${project.build.finalName}.${artifact.extension}</outputFileNameMapping>
+    </dependencySet>
+    <dependencySet>
+      <useProjectArtifact>false</useProjectArtifact>
       <scope>runtime</scope>
     </dependencySet>
   </dependencySets>

--- a/src/main/resources/assemblies/artifact.xml
+++ b/src/main/resources/assemblies/artifact.xml
@@ -8,6 +8,7 @@
       <includes>
         <include>${project.groupId}:${project.artifactId}</include>
       </includes>
+      <outputFileNameMapping>${project.build.finalName}.${artifact.extension}</outputFileNameMapping>
     </dependencySet>
   </dependencySets>
 </assembly>


### PR DESCRIPTION
fixes #111

Signed-off-by: Jae Gangemi <jgangemi@gmail.com>