### PR TITLE
allow containers to be named using its 'alias' 

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -9,6 +9,7 @@
   - Fix NPE when filtering enabled during assembly creation (#82)
   - Allow `${project.build.finalName}` to be overridden when using a pre-packaged assembly descriptor
     for artifacts (#111)
+  - allow containers to be named using `alias` when started (#48)
 
 * **0.11.1**
   - Add support for binding UDP ports (#83)

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -403,6 +403,9 @@ The `<run>` configuration knows the following sub elements:
   section. 
 * **memory** (*v1.11*) memory limit in bytes
 * **memorySwap** (*v1.11*) total memory usage (memory + swap); use -1 to disable swap.
+* **namingScheme** sets the name of the container
+-- `none` : uses randomly assigned names from docker, default value
+-- `alias` : uses the `alias` specifed in the `image` configuration 
 * **portPropertyFile**, if given, specifies a file into which the
   mapped properties should be written to. The format of this file and
   its purpose are also described [below](#port-mapping)
@@ -855,6 +858,7 @@ values in the `<build>` and `<run>` sections.
 * **docker.memory** Container memory (in bytes)
 * **docker.memorySwap** Total memory (swap + memory) `-1` to disable swap
 * **docker.name** Image name
+* **docker.namingScheme** Container naming
 * **docker.portPropertyFile** specifies a path to a port mapping used
   when starting a container.
 * **docker.ports.idx** Sets a port mapping. For example

--- a/src/main/java/org/jolokia/docker/maven/access/DockerAccess.java
+++ b/src/main/java/org/jolokia/docker/maven/access/DockerAccess.java
@@ -26,13 +26,14 @@ public interface DockerAccess {
 
     /**
      * Create a container from the given image.
-     *
+     * 
      * <p>The <code>container id</code> will be set on the <code>container</code> upon successful creation.</p>
      *
      * @param configuration container configuration
+     * @param containerName name container should be created with or <code>null</code> for a docker provided name
      * @throws DockerAccessException if the container could not be created.
      */
-    String createContainer(ContainerCreateConfig configuration) throws DockerAccessException;
+    String createContainer(ContainerCreateConfig configuration, String containerName) throws DockerAccessException;
 
     /**
      * Get the the name of a container for a given container id

--- a/src/main/java/org/jolokia/docker/maven/access/DockerAccessWithHttpClient.java
+++ b/src/main/java/org/jolokia/docker/maven/access/DockerAccessWithHttpClient.java
@@ -64,12 +64,12 @@ public class DockerAccessWithHttpClient implements DockerAccess {
     }
 
     @Override
-    public String createContainer(ContainerCreateConfig containerConfig) throws DockerAccessException {
+    public String createContainer(ContainerCreateConfig containerConfig, String containerName) throws DockerAccessException {
         String createJson = containerConfig.toJson();
         log.debug("Container create config: " + createJson);
 
         try {
-            String response = post(urlBuilder.createContainer(), createJson, HTTP_CREATED).getMessage();
+            String response = post(urlBuilder.createContainer(containerName), createJson, HTTP_CREATED).getMessage();
             JSONObject json = new JSONObject(response);
             logWarnings(json);
 
@@ -88,7 +88,12 @@ public class DockerAccessWithHttpClient implements DockerAccess {
             String response = get(urlBuilder.inspectContainer(containerId), HTTP_OK).getMessage();
             JSONObject json = new JSONObject(response);
             
-            return json.getString("Name");
+            String name =  json.getString("Name");
+            if (name.startsWith("/")) {
+                name = name.substring(1);
+            }
+            
+            return name;
         } catch (HttpRequestException e) {
             log.error(e.getMessage());
             throw new DockerAccessException("Unable to retrieve container name for [%s]", containerId);

--- a/src/main/java/org/jolokia/docker/maven/access/UrlBuilder.java
+++ b/src/main/java/org/jolokia/docker/maven/access/UrlBuilder.java
@@ -38,8 +38,11 @@ public final class UrlBuilder {
         return url;
     }
     
-    public String createContainer() {
-        return createUrl("/containers/create");
+    public String createContainer(String name) {
+        String url = createUrl("/containers/create");
+        url = addQueryParam(url, "name", name);
+        
+        return url;
     }
 
     public String deleteImage(String name, boolean force) {

--- a/src/main/java/org/jolokia/docker/maven/config/RunImageConfiguration.java
+++ b/src/main/java/org/jolokia/docker/maven/config/RunImageConfiguration.java
@@ -11,7 +11,7 @@ import java.util.Map;
 public class RunImageConfiguration {
 
     static final RunImageConfiguration DEFAULT = new RunImageConfiguration();
-
+    
     // Environment variables to set when starting the container. key: variable name, value: env value
     /**
      * @parameter
@@ -109,6 +109,9 @@ public class RunImageConfiguration {
      */
     private List<String> ports;
 
+    /** @parameter */
+    private NamingScheme namingScheme;
+    
     // Mount volumes from the given image's started containers
     /**
      * @parameter
@@ -220,6 +223,10 @@ public class RunImageConfiguration {
         return links;
     }
 
+    public NamingScheme getNamingScheme() {
+        return (namingScheme == null) ? NamingScheme.none : namingScheme;
+    }
+    
     public Boolean getPrivileged() {
         return privileged;
     }
@@ -227,8 +234,12 @@ public class RunImageConfiguration {
     public RestartPolicy getRestartPolicy() {
         return (restartPolicy == null) ? RestartPolicy.DEFAULT : restartPolicy;
     }
+    
+    public enum NamingScheme {
+        none, alias;
+    }
 
-// ======================================================================================
+    // ======================================================================================
 
     public static class Builder {
         private RunImageConfiguration config = new RunImageConfiguration();
@@ -333,6 +344,11 @@ public class RunImageConfiguration {
             return this;
         }
 
+        public Builder namingScheme(String namingScheme) {
+            config.namingScheme = (namingScheme == null) ? NamingScheme.none : NamingScheme.valueOf(namingScheme);
+            return this;
+        }
+        
         public Builder privileged(Boolean privileged) {
             config.privileged = privileged;
             return this;

--- a/src/main/java/org/jolokia/docker/maven/config/handler/property/ConfigKey.java
+++ b/src/main/java/org/jolokia/docker/maven/config/handler/property/ConfigKey.java
@@ -47,6 +47,7 @@ public enum ConfigKey {
     MEMORY,
     MEMORY_SWAP,
     NAME,
+    NAMING_SCHEME,
     PORT_PROPERTY_FILE,
     PORTS,
     PRIVILEGED,

--- a/src/main/java/org/jolokia/docker/maven/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/org/jolokia/docker/maven/config/handler/property/PropertyConfigHandler.java
@@ -18,12 +18,10 @@ package org.jolokia.docker.maven.config.handler.property;/*
 import java.util.*;
 
 import org.jolokia.docker.maven.config.*;
-import org.jolokia.docker.maven.config.RestartPolicy;
 import org.jolokia.docker.maven.config.handler.ExternalConfigHandler;
 import org.jolokia.docker.maven.util.EnvUtil;
 
 import static org.jolokia.docker.maven.config.handler.property.ConfigKey.*;
-
 import static org.jolokia.docker.maven.util.EnvUtil.*;
 
 /**
@@ -44,12 +42,9 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
         RunImageConfiguration run = extractRunConfiguration(prefix,properties);
         BuildImageConfiguration build = extractBuildConfiguration(prefix,properties);
 
-        String name = withPrefix(prefix, NAME, properties);
-        if (name == null) {
-            throw new IllegalArgumentException(String.format("Mandatory property [%s] is not defined", NAME));
-        }
+        String name = extractName(prefix, properties);
         String alias = withPrefix(prefix, ALIAS, properties);
-
+        
         return Collections.singletonList(
                 new ImageConfiguration.Builder()
                         .name(name)
@@ -88,6 +83,7 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
                 .links(listWithPrefix(prefix, LINKS, properties))
                 .memory(longWithPrefix(prefix, MEMORY, properties))
                 .memorySwap(longWithPrefix(prefix, MEMORY_SWAP, properties))
+                .namingScheme(withPrefix(prefix, NAMING_SCHEME, properties))
                 .portPropertyFile(withPrefix(prefix, PORT_PROPERTY_FILE, properties))
                 .ports(listWithPrefix(prefix, PORTS, properties))
                 .privileged(booleanWithPrefix(prefix, PRIVILEGED, properties))
@@ -111,6 +107,14 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
                 .build();
     }
     
+    private String extractName(String prefix, Properties properties) throws IllegalArgumentException {
+        String name = withPrefix(prefix, NAME, properties);
+        if (name == null) {
+            throw new IllegalArgumentException(String.format("Mandatory property [%s] is not defined", NAME));
+        }
+        return name;
+    }
+    
     // Extract only the values of the port mapping
     private List<String> extractPortValues(String prefix, Properties properties) {
         List<String> ret = new ArrayList<>();
@@ -124,7 +128,6 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
         }
         return ret;
     }
-
 
     private RestartPolicy extractRestartPolicy(String prefix, Properties properties) {
         return new RestartPolicy.Builder()
@@ -174,7 +177,7 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
         String prop = withPrefix(prefix,key,properties);
         return prop == null ? null : Boolean.valueOf(prop);
     }
-    
+
     private String getPrefix(ImageConfiguration config) {
         Map<String, String> refConfig = config.getExternalConfig();
         String prefix = refConfig != null ? refConfig.get("prefix") : null;

--- a/src/test/java/integration/DockerAccessIT.java
+++ b/src/test/java/integration/DockerAccessIT.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.*;
 @Ignore
 public class DockerAccessIT {
 
+    private static final String CONTAINER_NAME = "integration-test";
     private static final String IMAGE = "busybox:buildroot-2014.02";
     
     private static final String IMAGE_TAG = "busybox:tagged";
@@ -81,12 +82,11 @@ public class DockerAccessIT {
         ContainerHostConfig hostConfig = new ContainerHostConfig().portBindings(portMapping);
         ContainerCreateConfig createConfig = new ContainerCreateConfig(IMAGE).command("ping google.com").hostConfig(hostConfig);
         
-        containerId = dockerClient.createContainer(createConfig);
+        containerId = dockerClient.createContainer(createConfig, CONTAINER_NAME);
         assertNotNull(containerId);
 
-        // TODO: enhance this to check/set container name when issue 48 is resolved
         String name = dockerClient.getContainerName(containerId);
-        assertNotNull(name);       
+        assertEquals(CONTAINER_NAME, name);    
     }
     
     private void testDoesNotHave() throws DockerAccessException {

--- a/src/test/java/org/jolokia/docker/maven/config/handler/PropertyConfigHandlerTest.java
+++ b/src/test/java/org/jolokia/docker/maven/config/handler/PropertyConfigHandlerTest.java
@@ -18,9 +18,9 @@ package org.jolokia.docker.maven.config.handler;/*
 import java.util.*;
 
 import org.jolokia.docker.maven.config.*;
+import org.jolokia.docker.maven.config.RunImageConfiguration.NamingScheme;
 import org.junit.Before;
 import org.junit.Test;
-
 import org.jolokia.docker.maven.config.handler.property.ConfigKey;
 import org.jolokia.docker.maven.config.handler.property.PropertyConfigHandler;
 
@@ -106,6 +106,14 @@ public class PropertyConfigHandlerTest {
         assertFalse(config.exportBasedir());
         assertTrue(config.isIgnorePermissions());
     }
+
+    @Test
+    public void testNamingScheme() throws Exception  {
+        String[] testData = new String[] { k(NAME), "image", k(NAMING_SCHEME), NamingScheme.alias.toString() };
+        
+        ImageConfiguration config = resolveExternalImageConfig(testData);
+        assertEquals(NamingScheme.alias, config.getRunConfiguration().getNamingScheme());
+    }
     
     @Test
     public void testNoAssembly() throws Exception {
@@ -119,17 +127,24 @@ public class PropertyConfigHandlerTest {
     
     @Test
     public void testResolve() {
+        ImageConfiguration resolved = resolveExternalImageConfig(getTestData());
+
+        validateBuildConfiguration(resolved.getBuildConfiguration());
+        validateRunConfiguration(resolved.getRunConfiguration());
+    }
+    
+    private ImageConfiguration resolveExternalImageConfig(String[] testData) {
         Map<String, String> external = new HashMap<>();
         external.put("type", "props");
 
         ImageConfiguration config = new ImageConfiguration.Builder().name("image").alias("alias").externalConfig(external).build();
         PropertyConfigHandler handler = new PropertyConfigHandler();
-        List<ImageConfiguration> resolvedImageConfigs = handler.resolve(config, props(getTestData()));
+        
+        List<ImageConfiguration> resolvedImageConfigs = handler.resolve(config, props(testData));
         assertEquals(1,resolvedImageConfigs.size());
         ImageConfiguration resolved = resolvedImageConfigs.get(0);
 
-        validateBuildConfiguration(resolved.getBuildConfiguration());
-        validateRunConfiguration(resolved.getRunConfiguration());
+        return resolved;
     }
 
     private void validateBuildConfiguration(BuildImageConfiguration buildConfig) {
@@ -173,6 +188,7 @@ public class PropertyConfigHandlerTest {
         assertEquals(a("redis"), runConfig.getLinks());
         assertEquals((Long) 1L, runConfig.getMemory());
         assertEquals((Long) 1L, runConfig.getMemorySwap());
+        assertEquals(NamingScheme.none, runConfig.getNamingScheme());
         assertEquals("/tmp/props.txt", runConfig.getPortPropertyFile());
         assertEquals(a("8081:8080"), runConfig.getPorts());
         assertEquals(true, runConfig.getPrivileged());


### PR DESCRIPTION
- allow container to be named using `alias` when created/started

Signed-off-by: Jae Gangemi <jgangemi@gmail.com>