### PR TITLE
Do port/parameter substitution in environment variables

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.3.2</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
       <version>20140107</version>

--- a/src/main/java/org/jolokia/docker/maven/StartMojo.java
+++ b/src/main/java/org/jolokia/docker/maven/StartMojo.java
@@ -99,7 +99,7 @@ public class StartMojo extends AbstractDockerMojo {
                     .memorySwap(runConfig.getMemorySwap())
                     .entrypoint(runConfig.getEntrypoint())
                     .exposedPorts(mappedPorts.getContainerPorts())
-                    .environment(runConfig.getEnv())
+                    .environment(runConfig.getEnv(), project.getProperties())
                     .command(runConfig.getCommand())
                     .hostConfig(createContainerHostConfig(docker, runConfig, mappedPorts));
             VolumeConfiguration volumeConfig = runConfig.getVolumeConfiguration();

--- a/src/main/java/org/jolokia/docker/maven/StartMojo.java
+++ b/src/main/java/org/jolokia/docker/maven/StartMojo.java
@@ -222,7 +222,7 @@ public class StartMojo extends AbstractDockerMojo {
                 logOut.add("on log out '" + wait.getLog() + "'");
             }
             long waited = WaitUtil.wait(wait.getTime(), checkers.toArray(new WaitUtil.WaitChecker[0]));
-            log.info("Waited " + StringUtils.join(logOut.toArray(), " and ") + waited + " ms");
+            log.info("Waited " + StringUtils.join(logOut.toArray(), " and ") + " " + waited + " ms");
         }
     }
 

--- a/src/main/java/org/jolokia/docker/maven/access/ContainerCreateConfig.java
+++ b/src/main/java/org/jolokia/docker/maven/access/ContainerCreateConfig.java
@@ -2,6 +2,7 @@ package org.jolokia.docker.maven.access;
 
 import java.util.*;
 
+import org.apache.commons.lang3.text.StrSubstitutor;
 import org.jolokia.docker.maven.util.EnvUtil;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -54,7 +55,7 @@ public class ContainerCreateConfig {
         return a;
     }
 
-    public ContainerCreateConfig environment(Map<String, String> env) throws IllegalArgumentException {
+    public ContainerCreateConfig environment(Map<String, String> env, Properties properties) throws IllegalArgumentException {
         if (env != null && env.size() > 0) {
             JSONArray a = new JSONArray();
             for (Map.Entry<String, String> entry : env.entrySet()) {
@@ -63,7 +64,10 @@ public class ContainerCreateConfig {
                     throw new IllegalArgumentException(String.format("Env variable '%s' must not be null or empty",
                                                                      entry.getKey()));
                 }
-                a.put(entry.getKey() + "=" + entry.getValue());
+
+                StrSubstitutor substitutor = new StrSubstitutor();
+                String jsonString = entry.getKey() + "=" + substitutor.replace(value, properties);
+                a.put(jsonString);
             }
             createConfig.put("Env", a);
         }

--- a/src/test/java/org/jolokia/docker/maven/StartMojoContainerConfigsTest.java
+++ b/src/test/java/org/jolokia/docker/maven/StartMojoContainerConfigsTest.java
@@ -5,6 +5,7 @@ import java.util.*;
 
 import mockit.*;
 import org.apache.commons.io.IOUtils;
+import org.apache.maven.project.MavenProject;
 import org.jolokia.docker.maven.access.*;
 import org.jolokia.docker.maven.config.*;
 import org.junit.Test;
@@ -18,7 +19,10 @@ import org.skyscreamer.jsonassert.JSONAssert;
 public class StartMojoContainerConfigsTest {
 
     @Mocked
-    DockerAccess docker;
+    private DockerAccess docker;
+
+    @Mocked
+    private MavenProject mavenProject;
 
     @Test
     @SuppressWarnings("unused")
@@ -58,7 +62,14 @@ public class StartMojoContainerConfigsTest {
                         .build();
 
         StartMojo mojo = new StartMojo();
+        mojo.project = mavenProject;
         PortMapping portMapping = mojo.getPortMapping(runConfig, new Properties());
+
+        new Expectations() {{
+            mavenProject.getProperties();
+            result = new Properties();
+            minTimes = 1;
+        }};
 
         new Expectations() {{
             docker.getContainerName((String) withNotNull());

--- a/src/test/java/org/jolokia/docker/maven/assembly/DockerAssemblyConfigurationSourceTest.java
+++ b/src/test/java/org/jolokia/docker/maven/assembly/DockerAssemblyConfigurationSourceTest.java
@@ -78,16 +78,18 @@ public class DockerAssemblyConfigurationSourceTest {
         assertFalse(source.isIgnorePermissions());
 
         String outputDir = params.getOutputDirectory();
-        assertTrue(startsWithDir(outputDir, source.getOutputDirectory()));
-        assertTrue(startsWithDir(outputDir, source.getWorkingDirectory()));
-        assertTrue(startsWithDir(outputDir, source.getTemporaryRootDirectory()));
+        assertStartsWithDir(outputDir, source.getOutputDirectory());
+        assertStartsWithDir(outputDir, source.getWorkingDirectory());
+        assertStartsWithDir(outputDir, source.getTemporaryRootDirectory());
     }
 
     private boolean containsDir(String outputDir, File path) {
         return path.toString().contains(outputDir + File.separator);
     }
     
-    private boolean startsWithDir(String outputDir, File path) {
-        return path.toString().startsWith(outputDir + File.separator);
+    private void assertStartsWithDir(String outputDir, File path) {
+        String expectedStartsWith = outputDir + File.separator;
+        int length = expectedStartsWith.length();
+        assertEquals(expectedStartsWith, path.toString().substring(0, length));
     }
 }


### PR DESCRIPTION
I had a need for port/parameter substitution in environment variables. I wanted to set the database URL on my second container, that had the port as determined for the first container.

E.g., the second container had something like this:

    <env>
        <DATABASE_URL>jdbc\:mysql\://${env.DOCKER_HOST_HOST}:${database.port}/</DATABASE_URL>
    </env>

The code in the merge request does this, plus a few minor other snippets.