### PR TITLE
Output to dir is now an archive.

### DIFF
--- a/src/main/java/org/jolokia/docker/maven/assembly/DockerAssemblyManager.java
+++ b/src/main/java/org/jolokia/docker/maven/assembly/DockerAssemblyManager.java
@@ -102,7 +102,9 @@ public class DockerAssemblyManager {
         try {
             TarArchiver archiver = (TarArchiver) archiverManager.getArchiver("tar");
             archiver.setLongfile(TarLongFileMode.posix);
-            archiver.addFileSet(DefaultFileSet.fileSet(buildDirs.getOutputDirectory()));
+//            archiver.addFileSet(DefaultFileSet.fileSet(buildDirs.getOutputDirectory()));
+            archiver.addArchivedFileSet(new File(buildDirs.getOutputDirectory(),"maven.tgz"),"maven/");
+            archiver.addFile(new File(buildDirs.getOutputDirectory(),"Dockerfile"), "Dockerfile");
             if (extraDir != null) {
                 archiver.addFileSet(DefaultFileSet.fileSet(extraDir));
             }    
@@ -154,7 +156,7 @@ public class DockerAssemblyManager {
 
         try {
             assembly.setId("docker");
-            assemblyArchiver.createArchive(assembly, "maven", "dir", source, false);
+            assemblyArchiver.createArchive(assembly, "maven", "tgz", source, false);
         } catch (ArchiveCreationException | AssemblyFormattingException e) {
             throw new MojoExecutionException( "Failed to create assembly for docker image: " + e.getMessage(), e );
         } catch (InvalidAssemblerConfigurationException e) {

--- a/src/main/java/org/jolokia/docker/maven/assembly/DockerAssemblyManager.java
+++ b/src/main/java/org/jolokia/docker/maven/assembly/DockerAssemblyManager.java
@@ -104,10 +104,15 @@ public class DockerAssemblyManager {
             archiver.setLongfile(TarLongFileMode.posix);
 //            archiver.addFileSet(DefaultFileSet.fileSet(buildDirs.getOutputDirectory()));
             archiver.addArchivedFileSet(new File(buildDirs.getOutputDirectory(),"maven.tgz"),"maven/");
-            archiver.addFile(new File(buildDirs.getOutputDirectory(),"Dockerfile"), "Dockerfile");
+          
             if (extraDir != null) {
                 archiver.addFileSet(DefaultFileSet.fileSet(extraDir));
-            }    
+                
+            }
+            if( extraDir == null || ! new File(extraDir,"Dockerfile").exists()) 
+            {//only add docker file if not in extra
+            	  archiver.addFile(new File(buildDirs.getOutputDirectory(),"Dockerfile"), "Dockerfile");
+            }
             archiver.setDestFile(archive);
             archiver.createArchive();
             return archive;

--- a/src/main/resources/assemblies/rootWar.xml
+++ b/src/main/resources/assemblies/rootWar.xml
@@ -8,7 +8,6 @@
       <includes>
         <include>${project.groupId}:${project.artifactId}</include>
       </includes>
-      <outputDirectory>.</outputDirectory>
       <outputFileNameMapping>ROOT.war</outputFileNameMapping>
     </dependencySet>
   </dependencySets>

--- a/src/main/resources/assemblies/rootWar.xml
+++ b/src/main/resources/assemblies/rootWar.xml
@@ -8,6 +8,7 @@
       <includes>
         <include>${project.groupId}:${project.artifactId}</include>
       </includes>
+      <outputDirectory>.</outputDirectory>
       <outputFileNameMapping>ROOT.war</outputFileNameMapping>
     </dependencySet>
   </dependencySets>

--- a/src/test/java/org/jolokia/docker/maven/assembly/DockerAssemblyConfigurationSourceTest.java
+++ b/src/test/java/org/jolokia/docker/maven/assembly/DockerAssemblyConfigurationSourceTest.java
@@ -1,5 +1,9 @@
 package org.jolokia.docker.maven.assembly;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 
 import org.apache.maven.project.MavenProject;
@@ -8,8 +12,6 @@ import org.jolokia.docker.maven.util.EnvUtil;
 import org.jolokia.docker.maven.util.MojoParameters;
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.junit.Assert.*;
 
 public class DockerAssemblyConfigurationSourceTest {
 
@@ -27,12 +29,12 @@ public class DockerAssemblyConfigurationSourceTest {
 
     @Test
     public void testCreateSourceAbsolute() {
-        testCreateSource(buildParameters(".", "/src/docker", "/output/docker"));
+        testCreateSource(buildParameters(".", "/src/docker".replace("/", File.separator), "/output/docker".replace("/", File.separator)));
     }
 
     @Test
     public void testCreateSourceRelative() {
-        testCreateSource(buildParameters(".","src/docker", "output/docker"));
+        testCreateSource(buildParameters(".","src/docker".replace("/", File.separator), "output/docker".replace("/", File.separator)));
     }
 
     @Test
@@ -69,18 +71,18 @@ public class DockerAssemblyConfigurationSourceTest {
         String[] descriptors = source.getDescriptors();
         String[] descriptorRefs = source.getDescriptorReferences();
 
-        assertEquals(1, descriptors.length);
-        assertEquals(EnvUtil.prepareAbsoluteSourceDirPath(params, "assembly.xml").getAbsolutePath(), descriptors[0]);
+        assertEquals("count of descriptors", 1, descriptors.length);
+        assertEquals("directory of assembly", EnvUtil.prepareAbsoluteSourceDirPath(params, "assembly.xml").getAbsolutePath(), descriptors[0]);
 
-        assertEquals(1, descriptorRefs.length);
-        assertEquals("project", descriptorRefs[0]);
+        assertEquals("count of descriptors references", 1, descriptorRefs.length);
+        assertEquals("reference must be project", "project", descriptorRefs[0]);
 
-        assertFalse(source.isIgnorePermissions());
+        assertFalse("We must not ignore permissions problems", source.isIgnorePermissions());
 
         String outputDir = params.getOutputDirectory();
-        assertTrue(startsWithDir(outputDir, source.getOutputDirectory()));
-        assertTrue(startsWithDir(outputDir, source.getWorkingDirectory()));
-        assertTrue(startsWithDir(outputDir, source.getTemporaryRootDirectory()));
+        assertTrue("validate start of output Directory is same than outputdir", startsWithDir(outputDir, source.getOutputDirectory()));
+        assertTrue("validate start of working Directory is same than outputdir",startsWithDir(outputDir, source.getWorkingDirectory()));
+        assertTrue("validate start of temporary directory is same than outputdir", startsWithDir(outputDir, source.getTemporaryRootDirectory()));
     }
 
     private boolean containsDir(String outputDir, File path) {


### PR DESCRIPTION
The temporary assembly is now outputdir/build/maven.tgz instead of a directory (was outputdir/build/maven/


Aim to fix the files/directory rights defined in assembly issue which appear for some windows users.
The problem is that the fat/ntfs or any other file systeme like this ones which does not support linux like rights)
The solution is to use a system that does not rely on underling File system. choosen to use tgz archive.

Fixed some unit test issues under windows.
