### PR TITLE
Add parameter to allow skipping of tagging

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,5 +1,8 @@
 # ChangeLog
 
+* **0.12**
+  - Add a new parameter 'docker.skipTags' that suppresses tagging of images that have been built.
+
 * **0.11.5**
   - Fix problem with http:// URLs when a CERT path is set
   - Fix warnings when parsing a pull response

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -114,6 +114,8 @@ parentheses.
 * **skip** (`docker.skip`)
   With this parameter the execution of this plugin can be skipped
   completely. 
+* **skipTags** (`docker.skipTags`)
+  If set to `true` the plugin won't add any tags to images that have been built.
 * **registry** (`docker.registry`)
   Specify globally a registry to use for pulling and pushing
   images. See [Registry handling](#registry-handling) for details. 

--- a/src/main/java/org/jolokia/docker/maven/BuildMojo.java
+++ b/src/main/java/org/jolokia/docker/maven/BuildMojo.java
@@ -55,6 +55,11 @@ public class BuildMojo extends AbstractDockerMojo {
      */
     private String outputDirectory;
     
+    /**
+     * @parameter default-value="false" property="docker.skipTags"
+     */
+    private boolean skipTags;
+
     @Override
     protected void executeInternal(DockerAccess dockerAccess) throws DockerAccessException, MojoExecutionException {
         for (ImageConfiguration imageConfig : getImages()) {
@@ -85,6 +90,11 @@ public class BuildMojo extends AbstractDockerMojo {
 
     private void tagImage(String imageName, ImageConfiguration imageConfig, DockerAccess dockerAccess)
             throws DockerAccessException, MojoExecutionException {
+
+        if (skipTags) {
+            return;
+        }
+
         List<String> tags = imageConfig.getBuildConfiguration().getTags();
         if (tags.size() > 0) {
             log.info("Tagging image " + imageConfig.getDescription() + ": " + EnvUtil.stringJoin(tags, ","));


### PR DESCRIPTION
Naive approach to be able to skip tagging of images during `docker:build` using a property. When `docker.skipTags` is `true`, then built images won't be tagged.