### PR TITLE
Add CMD and ENTRYPOINT (fixes #130)

### DIFF
--- a/doc/manual.md
+++ b/doc/manual.md
@@ -228,8 +228,10 @@ of an image configuration. The available subelements are
 
 * **assembly** specifies the assembly configuration as described in
   [Build Assembly](#build-assembly)
-* **command** is the command to execute by default (i.e. if no command
-  is provided when a container for this image is started).
+* **cmd** A command to execute by default.
+  [Start-up Arguments]
+* **entrypoint** An ENTRYPOINT allows you to configure a container that will run as an executable.  
+  [Start-up Arguments]
 * **env** hold environments as described in
   [Setting Environment Variables](#setting-environment-variables). 
 * **from** specifies the base image which should be used for this
@@ -263,7 +265,16 @@ Here's an example:
   <volumes>
     <volume>/path/to/expose</volume>
   </volumes>
-  <command>java /opt/demo/server.jar</command>
+  
+  <entryPoint>
+    <!-- exec form for ENTRYPOINT -->
+    <params>
+      <param>java</param>
+      <param>-jar</param>
+      <param>/opt/demo/server.jar</param>
+    </params>
+  </entryPoint>
+
   <assembly>
     <mode>dir</mode>
     <basedir>/opt/demo</basedir>
@@ -315,7 +326,29 @@ Here's an example:
   `jboss:jboss:jboss` would be required. 
 
 In the event you do not need to include any artifacts with the image, you may
-safely omit this element from the configuration. 
+safely omit this element from the configuration.
+
+##### Start-up Arguments
+Using `entryPoint` and `cmd` it is possible to specify [entry point](https://docs.docker.com/reference/builder/#entrypoint) or [cmd](https://docs.docker.com/reference/builder/#cmd) for a container
+
+* **shell** shell form, translated to the docker file as is
+* **params** list of arguments which will transformed into exec form
+Either shell or params should be specified. 
+
+Example:
+ 
+````xml
+ <entryPoint>
+    <!-- shell form for entry point -->
+    <shell>java -jar /opt/demo/server.jar</shell>
+    <!-- or exec form for entry -->
+    <params>
+      <param>java</param>
+      <param>-jar</param>
+      <param>/opt/demo/server.jar</param>
+    </params>
+  </entryPoint>
+````
 
 ##### Docker Assembly
 

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,12 @@
       <version>1.5.5</version>
     </dependency>
 
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>18.0</version>
+    </dependency>
+
     <!-- =============================================================================== -->
 
     <dependency>

--- a/src/main/java/org/jolokia/docker/maven/BuildMojo.java
+++ b/src/main/java/org/jolokia/docker/maven/BuildMojo.java
@@ -60,6 +60,7 @@ public class BuildMojo extends AbstractDockerMojo {
         for (ImageConfiguration imageConfig : getImages()) {
             BuildImageConfiguration buildConfig = imageConfig.getBuildConfiguration();
             if (buildConfig != null) {
+                buildConfig.validate();
                 String imageName = imageConfig.getName();
                 buildImage(imageName, imageConfig, dockerAccess);
                 tagImage(imageName, imageConfig, dockerAccess);

--- a/src/main/java/org/jolokia/docker/maven/StartMojo.java
+++ b/src/main/java/org/jolokia/docker/maven/StartMojo.java
@@ -185,7 +185,7 @@ public class StartMojo extends AbstractDockerMojo {
                     .entrypoint(runConfig.getEntrypoint())
                     .exposedPorts(mappedPorts.getContainerPorts())
                     .environment(runConfig.getEnvPropertyFile(), runConfig.getEnv(), project.getProperties())
-                    .command(runConfig.getCommand())
+                    .command(runConfig.getCmd())
                     .hostConfig(createContainerHostConfig(docker, runConfig, mappedPorts));
             VolumeConfiguration volumeConfig = runConfig.getVolumeConfiguration();
             if (volumeConfig != null) {

--- a/src/main/java/org/jolokia/docker/maven/assembly/DockerAssemblyManager.java
+++ b/src/main/java/org/jolokia/docker/maven/assembly/DockerAssemblyManager.java
@@ -78,7 +78,7 @@ public class DockerAssemblyManager {
                 DockerFileBuilder builder = createDockerFileBuilder(buildConfig, assemblyConfig);
                 builder.write(buildDirs.getOutputDirectory());
             }
-            return createTarball(buildDirs,extraDir,assemblyConfig.getMode());
+            return createTarball(buildDirs, extraDir, assemblyConfig.getMode());
 
         } catch (IOException e) {
             throw new MojoExecutionException(String.format("Cannot create Dockerfile in %s", buildDirs.getOutputDirectory()), e);
@@ -158,12 +158,15 @@ public class DockerAssemblyManager {
         }
 
         builder.baseImage(buildConfig.getFrom());
-        builder.command((String[]) null); // Use command from base image (gets overwritten below if explicitly set)
 
-        if (buildConfig.getCommand() != null) {
-            builder.command(EnvUtil.splitOnSpaceWithEscape(buildConfig.getCommand()));
+        if (buildConfig.getCmd() != null){
+            builder.cmd(buildConfig.getCmd());
         }
 
+        if (buildConfig.getEntryPoint() != null){
+            builder.entryPoint(buildConfig.getEntryPoint());
+        }
+        
         return builder;
     }
 

--- a/src/main/java/org/jolokia/docker/maven/config/Arguments.java
+++ b/src/main/java/org/jolokia/docker/maven/config/Arguments.java
@@ -1,0 +1,71 @@
+package org.jolokia.docker.maven.config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Arguments {
+
+    /**
+     * @parameter
+     */
+    private String shell;
+
+    /**
+     * @parameter
+     */
+    private List<String> params;
+
+    public void setShell(String shell) {
+        this.shell = shell;
+    }
+
+    public String getShell() {
+        return shell;
+    }
+
+    public void setParams(List<String> params) {
+        this.params = params;
+    }
+
+    public List<String> getParams() {
+        return params;
+    }
+
+    public void validate() throws IllegalArgumentException {
+        if (shell == null && (params == null || params.isEmpty())){
+            throw new IllegalArgumentException("Argument conflict, either shell or params should be specified");
+        }
+        if (shell != null && params != null) {
+            throw new IllegalArgumentException("Argument conflict, either shell or params should be specified");
+        }
+    }
+
+    public static class Builder {
+        private String shell;
+        private List<String> params;
+
+        public static Builder get(){
+            return new Builder();
+        }
+
+        public Builder withShell(String shell){
+            this.shell = shell;
+            return this;
+        }
+
+        public Builder withParam(String param){
+            if (params == null) {
+                params = new ArrayList<>();
+            }
+            this.params.add(param);
+            return this;
+        }
+
+        public Arguments build(){
+            Arguments a = new Arguments();
+            a.setShell(shell);
+            a.setParams(params);
+            return a;
+        }
+    }
+}

--- a/src/main/java/org/jolokia/docker/maven/config/BuildImageConfiguration.java
+++ b/src/main/java/org/jolokia/docker/maven/config/BuildImageConfiguration.java
@@ -1,6 +1,10 @@
 package org.jolokia.docker.maven.config;
 
-import java.util.*;
+import org.apache.maven.plugin.MojoExecutionException;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 /**
  * @author roland
@@ -42,12 +46,17 @@ public class BuildImageConfiguration {
     /**
      * @parameter
      */
-     private Map<String,String> env;
+    private Map<String,String> env;
 
     /**
      * @parameter
      */
-    private String command;
+    private Arguments entryPoint;
+
+    /**
+     * @parameter
+     */
+    private Arguments cmd;
 
     /**
      * @parameter
@@ -88,8 +97,12 @@ public class BuildImageConfiguration {
         return env;
     }
     
-    public String getCommand() {
-        return command;
+    public Arguments getCmd() {
+        return cmd;
+    }
+
+    public Arguments getEntryPoint() {
+        return entryPoint;
     }
 
     public static class Builder {
@@ -135,13 +148,33 @@ public class BuildImageConfiguration {
             return this;
         }
 
-        public Builder command(String command) {
-            config.command = command;
+        public Builder cmd(String cmd) {
+            if (config.cmd == null) {
+                config.cmd = new Arguments();
+            }
+            config.cmd.setShell(cmd);
+            return this;
+        }
+
+        public Builder entryPoint(String entryPoint) {
+            if (config.entryPoint == null) {
+                config.entryPoint = new Arguments();
+            }
+            config.entryPoint.setShell(entryPoint);
             return this;
         }
 
         public BuildImageConfiguration build() {
             return config;
+        }
+    }
+
+    public void validate() throws MojoExecutionException {
+        if (entryPoint != null) {
+            entryPoint.validate();
+        }
+        if (cmd != null) {
+            cmd.validate();
         }
     }
 }

--- a/src/main/java/org/jolokia/docker/maven/config/RunImageConfiguration.java
+++ b/src/main/java/org/jolokia/docker/maven/config/RunImageConfiguration.java
@@ -29,7 +29,7 @@ public class RunImageConfiguration {
     /**
      * @parameter
      */
-    private String command;
+    private String cmd;
 
     // container domain name
     /**
@@ -197,8 +197,8 @@ public class RunImageConfiguration {
         return ports;
     }
 
-    public String getCommand() {
-        return command;
+    public String getCmd() {
+        return cmd;
     }
 
     public String getPortPropertyFile() {
@@ -277,8 +277,8 @@ public class RunImageConfiguration {
         }
 
 
-        public Builder command(String command) {
-            config.command = command;
+        public Builder cmd(String cmd) {
+            config.cmd = cmd;
             return this;
         }
 

--- a/src/main/java/org/jolokia/docker/maven/config/handler/property/ConfigKey.java
+++ b/src/main/java/org/jolokia/docker/maven/config/handler/property/ConfigKey.java
@@ -34,7 +34,7 @@ public enum ConfigKey {
     BIND,
     CAP_ADD,
     CAP_DROP,
-    COMMAND,
+    CMD,
     DOMAINNAME,
     DNS,
     DNS_SEARCH,

--- a/src/main/java/org/jolokia/docker/maven/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/org/jolokia/docker/maven/config/handler/property/PropertyConfigHandler.java
@@ -56,7 +56,8 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
 
     private BuildImageConfiguration extractBuildConfiguration(String prefix, Properties properties) {
         return new BuildImageConfiguration.Builder()
-                .command(withPrefix(prefix, COMMAND, properties))
+                .cmd(withPrefix(prefix, CMD, properties))
+                .entryPoint(withPrefix(prefix, ENTRYPOINT, properties))
                 .assembly(extractAssembly(prefix, properties))
                 .env(mapWithPrefix(prefix, ENV, properties))
                 .ports(extractPortValues(prefix, properties))
@@ -73,7 +74,7 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
         return new RunImageConfiguration.Builder()
                 .capAdd(listWithPrefix(prefix, CAP_ADD, properties))
                 .capDrop(listWithPrefix(prefix, CAP_DROP, properties))
-                .command(withPrefix(prefix, COMMAND, properties))
+                .cmd(withPrefix(prefix, CMD, properties))
                 .dns(listWithPrefix(prefix, DNS, properties))
                 .dnsSearch(listWithPrefix(prefix, DNS_SEARCH, properties))
                 .domainname(withPrefix(prefix, DOMAINNAME, properties))

--- a/src/test/java/org/jolokia/docker/maven/StartMojoContainerConfigsTest.java
+++ b/src/test/java/org/jolokia/docker/maven/StartMojoContainerConfigsTest.java
@@ -48,7 +48,7 @@ public class StartMojoContainerConfigsTest {
                         .memory(1L)
                         .memorySwap(1L)
                         .env(env())
-                        .command("date")
+                        .cmd("date")
                         .entrypoint("entrypoint")
                         .extraHosts(extraHosts())
                         .workingDir("/foo")
@@ -92,23 +92,23 @@ public class StartMojoContainerConfigsTest {
     }
 
     private List<String> bind() {
-        return Arrays.asList("/host_tmp:/container_tmp");
+        return Collections.singletonList("/host_tmp:/container_tmp");
     }
 
     private List<String> capAdd() {
-        return Arrays.asList("NET_ADMIN");
+        return Collections.singletonList("NET_ADMIN");
     }
 
     private List<String> capDrop() {
-        return Arrays.asList("MKNOD");
+        return Collections.singletonList("MKNOD");
     }
 
     private List<String> dns() {
-        return Arrays.asList("8.8.8.8");
+        return Collections.singletonList("8.8.8.8");
     }
 
     private List<String> dnsSearch() {
-        return Arrays.asList("domain.com");
+        return Collections.singletonList("domain.com");
     }
 
     private Map<String, String> env() {
@@ -119,11 +119,11 @@ public class StartMojoContainerConfigsTest {
     }
 
     private List<String> extraHosts() {
-        return Arrays.asList("localhost:127.0.0.1");
+        return Collections.singletonList("localhost:127.0.0.1");
     }
 
     private List<String> links() {
-        return Arrays.asList("redis3:redis");
+        return Collections.singletonList("redis3:redis");
     }
 
     private String loadFile(String fileName) throws IOException {
@@ -131,7 +131,7 @@ public class StartMojoContainerConfigsTest {
     }
 
     private List<String> ports() {
-        return Arrays.asList("0.0.0.0:11022:22");
+        return Collections.singletonList("0.0.0.0:11022:22");
     }
 
     private RestartPolicy restartPolicy() {

--- a/src/test/java/org/jolokia/docker/maven/config/handler/property/PropertyConfigHandlerTest.java
+++ b/src/test/java/org/jolokia/docker/maven/config/handler/property/PropertyConfigHandlerTest.java
@@ -85,7 +85,7 @@ public class PropertyConfigHandlerTest {
 
         assertEquals(1,configs.size());
         ImageConfiguration calcConfig = configs.get(0);
-        for (Map<String,String> env : new Map[] { calcConfig.getBuildConfiguration().getEnv(),
+        for (Map env : new Map[] { calcConfig.getBuildConfiguration().getEnv(),
                                                   calcConfig.getRunConfiguration().getEnv()}) {
             assertEquals(2,env.size());
             assertEquals("/tmp",env.get("HOME"));
@@ -115,7 +115,7 @@ public class PropertyConfigHandlerTest {
     
     @Test
     public void testNoAssembly() throws Exception {
-        Properties props = props(new String[] { k(NAME), "image" });
+        Properties props = props(k(NAME), "image");
         List<ImageConfiguration> configs = configHandler.resolve(imageConfiguration, props);
         assertEquals(1, configs.size());
 
@@ -140,13 +140,12 @@ public class PropertyConfigHandlerTest {
         
         List<ImageConfiguration> resolvedImageConfigs = handler.resolve(config, props(testData));
         assertEquals(1, resolvedImageConfigs.size());
-        ImageConfiguration resolved = resolvedImageConfigs.get(0);
 
-        return resolved;
+        return resolvedImageConfigs.get(0);
     }
 
     private void validateBuildConfiguration(BuildImageConfiguration buildConfig) {
-        assertEquals("command.sh", buildConfig.getCommand());
+        assertEquals("command.sh", buildConfig.getCmd().getShell());
         assertEquals("image", buildConfig.getFrom());
         assertEquals(a("8080"), buildConfig.getPorts());
         assertEquals("registry", buildConfig.getRegistry());
@@ -177,7 +176,7 @@ public class PropertyConfigHandlerTest {
         assertEquals(a("/foo", "/tmp:/tmp"), runConfig.getVolumeConfiguration().getBind());
         assertEquals(a("CAP"), runConfig.getCapAdd());
         assertEquals(a("CAP"), runConfig.getCapDrop());
-        assertEquals("command.sh", runConfig.getCommand());
+        assertEquals("command.sh", runConfig.getCmd());
         assertEquals(a("8.8.8.8"), runConfig.getDns());
         assertEquals(a("example.com"), runConfig.getDnsSearch());
         assertEquals("domain.com", runConfig.getDomainname());
@@ -240,7 +239,7 @@ public class PropertyConfigHandlerTest {
                 k(BIND) + ".2", "/tmp:/tmp",
                 k(CAP_ADD) + ".1", "CAP",
                 k(CAP_DROP) + ".1", "CAP",
-                k(COMMAND), "command.sh",
+                k(CMD), "command.sh",
                 k(DNS) + ".1", "8.8.8.8",
                 k(DNS_SEARCH) + ".1", "example.com",
                 k(DOMAINNAME), "domain.com",


### PR DESCRIPTION
introduced cmd and entrypoint with exec and shell form support.
the change is not backward compatible to the previous version.

Signed-off-by: Oleg Sigida <oleg.sigida@gmail.com>