### PR TITLE
Allow dynamic ports to be override by System properties.

### DIFF
--- a/src/main/java/org/jolokia/docker/maven/StartMojo.java
+++ b/src/main/java/org/jolokia/docker/maven/StartMojo.java
@@ -60,7 +60,10 @@ public class StartMojo extends AbstractDockerMojo {
             checkImageWithAutoPull(docker, imageName, getRegistry(imageConfig));
 
             RunImageConfiguration runConfig = imageConfig.getRunConfiguration();
-            PortMapping mappedPorts = getPortMapping(runConfig, project.getProperties());
+            Properties properties = new Properties();
+            properties.putAll(project.getProperties());
+            properties.putAll(System.getProperties());
+            PortMapping mappedPorts = getPortMapping(runConfig, properties);
 
             String name = calculateContainerName(imageConfig.getAlias(), runConfig.getNamingStrategy());
             ContainerCreateConfig config = createContainerConfig(docker, imageName, runConfig, mappedPorts);


### PR DESCRIPTION
Previous behavior only allowed project properties to override them.
Even the documentation suggested that you could override them by passing
-Dfoo=bar on the mvn cli, but this wasn't actually the case.

Signed-off-by: Ben Reser <ben.reser@cdk.com>