### PR TITLE
Fix log messages getting cut off in the build

### DIFF
--- a/src/main/java/org/jolokia/docker/maven/access/log/LogRequestor.java
+++ b/src/main/java/org/jolokia/docker/maven/access/log/LogRequestor.java
@@ -104,11 +104,11 @@ public class LogRequestor extends Thread implements LogGetHandle {
         try (InputStream is = response.getEntity().getContent()) {
             byte[] headBuf = new byte[8];
             byte[] buf = new byte[8129];
-            while (IOUtils.read(is, headBuf, 0, 8) != -1) {
+            while (IOUtils.read(is, headBuf, 0, 8) > 0) {
                 int type = headBuf[0];
                 int declaredLength = extractLength(headBuf);
                 int len = IOUtils.read(is, buf, 0, declaredLength);
-                if (len == -1) {
+                if (len < 1) {
                     callback.error("Invalid log format: Couldn't read " + declaredLength + " bytes from stream");
                     finish();
                     return;

--- a/src/main/java/org/jolokia/docker/maven/access/log/LogRequestor.java
+++ b/src/main/java/org/jolokia/docker/maven/access/log/LogRequestor.java
@@ -20,6 +20,7 @@ import java.io.InputStream;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
 import org.apache.http.client.HttpClient;
@@ -103,10 +104,10 @@ public class LogRequestor extends Thread implements LogGetHandle {
         try (InputStream is = response.getEntity().getContent()) {
             byte[] headBuf = new byte[8];
             byte[] buf = new byte[8129];
-            while (is.read(headBuf, 0, 8) != -1) {
+            while (IOUtils.read(is, headBuf, 0, 8) != -1) {
                 int type = headBuf[0];
                 int declaredLength = extractLength(headBuf);
-                int len = is.read(buf, 0, declaredLength);
+                int len = IOUtils.read(is, buf, 0, declaredLength);
                 if (len == -1) {
                     callback.error("Invalid log format: Couldn't read " + declaredLength + " bytes from stream");
                     finish();


### PR DESCRIPTION
Hi,

I was getting log messages being cut off in the build:

[ERROR] DOCKER> Invalid log format for '201' (expected: "<timestamp> <txt>")

I switched this method:

https://docs.oracle.com/javase/7/docs/api/java/io/InputStream.html#read(byte[],%20int,%20int)

"An attempt is made to read as many as len bytes, but a smaller number may be read. The number of bytes actually read is returned as an integer."

for this method:

https://commons.apache.org/proper/commons-io/apidocs/org/apache/commons/io/IOUtils.html#read(java.io.InputStream, byte[], int, int)

"This implementation guarantees that it will read as many bytes as possible before giving up"

Cheers,
Dan