### PR TITLE
Chunked response errors should fail plugin execution

### DIFF
--- a/src/main/java/org/jolokia/docker/maven/access/chunked/ChunkedResponseHandler.java
+++ b/src/main/java/org/jolokia/docker/maven/access/chunked/ChunkedResponseHandler.java
@@ -1,5 +1,7 @@
 package org.jolokia.docker.maven.access.chunked;
 
+import org.jolokia.docker.maven.access.DockerAccessException;
+
 public interface ChunkedResponseHandler<T> {
-    void process(T toProcess);
+    void process(T toProcess) throws DockerAccessException;
 }

--- a/src/main/java/org/jolokia/docker/maven/access/chunked/ChunkedResponseReader.java
+++ b/src/main/java/org/jolokia/docker/maven/access/chunked/ChunkedResponseReader.java
@@ -1,5 +1,7 @@
 package org.jolokia.docker.maven.access.chunked;
 
+import org.jolokia.docker.maven.access.DockerAccessException;
+
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -13,7 +15,7 @@ public class ChunkedResponseReader {
         this.handler = handler;
     }        
     
-    public void process() throws IOException {
+    public void process() throws IOException, DockerAccessException {
         int len;
         int size = 8129;
         byte[] buf = new byte[size];

--- a/src/main/java/org/jolokia/docker/maven/access/chunked/PullOrPushResponseHandler.java
+++ b/src/main/java/org/jolokia/docker/maven/access/chunked/PullOrPushResponseHandler.java
@@ -1,5 +1,6 @@
 package org.jolokia.docker.maven.access.chunked;
 
+import org.jolokia.docker.maven.access.DockerAccessException;
 import org.jolokia.docker.maven.util.Logger;
 import org.json.JSONObject;
 
@@ -14,7 +15,7 @@ public class PullOrPushResponseHandler implements ChunkedResponseHandler<JSONObj
     }
     
     @Override
-    public void process(JSONObject json) {
+    public void process(JSONObject json) throws DockerAccessException {
         if (json.has("progressDetail")) {
             JSONObject details = json.getJSONObject("progressDetail");
             if (details.has("total")) {
@@ -35,6 +36,7 @@ public class PullOrPushResponseHandler implements ChunkedResponseHandler<JSONObj
             String msg = json.getString("error").trim();
             String details = json.getJSONObject("errorDetail").getString("message").trim();
             log.error(msg + (msg.equals(details) ? "" : "(" + details + ")"));
+            throw new DockerAccessException("%s %s", msg, (msg.equals(details) ? "" : "(" + details + ")"));
         } else {
             log.info("... " + (json.has("id") ? json.getString("id") + ": " : "") + json.getString("status"));
         }

--- a/src/main/java/org/jolokia/docker/maven/access/chunked/TextToJsonBridgeCallback.java
+++ b/src/main/java/org/jolokia/docker/maven/access/chunked/TextToJsonBridgeCallback.java
@@ -1,5 +1,6 @@
 package org.jolokia.docker.maven.access.chunked;
 
+import org.jolokia.docker.maven.access.DockerAccessException;
 import org.jolokia.docker.maven.util.Logger;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -16,7 +17,7 @@ public class TextToJsonBridgeCallback implements ChunkedResponseHandler<String>
     }
 
     @Override
-    public void process(String text) {
+    public void process(String text) throws DockerAccessException {
         try {
             JSONObject json = new JSONObject(text);
             handler.process(json);


### PR DESCRIPTION
This is a pull request to fix this issue: https://github.com/rhuss/docker-maven-plugin/issues/167

I saw that there was already some processing around chunked responses to parse them and log their messages. This just takes it one small step further and throws an exception if the chucked response contains an error (effectively causing the plugin execution to fail).