### PR TITLE
Add Support for communication to docker hosts using UNIX domain sockets

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,12 @@
     </dependency>
 
     <dependency>
+        <groupId>com.github.jnr</groupId>
+        <artifactId>jnr-unixsocket</artifactId>
+        <version>0.8</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>3.3.2</version>

--- a/src/main/java/org/jolokia/docker/maven/AbstractDockerMojo.java
+++ b/src/main/java/org/jolokia/docker/maven/AbstractDockerMojo.java
@@ -1,8 +1,8 @@
 package org.jolokia.docker.maven;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.*;
 
 import org.apache.maven.plugin.*;
@@ -248,11 +248,14 @@ public abstract class AbstractDockerMojo extends AbstractMojo implements Context
 
     // Registry for managed containers
     private void setDockerHostAddressProperty(String dockerUrl) throws MojoFailureException {
+        final String host;
         try {
-            project.getProperties().setProperty("docker.host.address", new URL(dockerUrl).getHost());
-        } catch (MalformedURLException e) {
-            throw new MojoFailureException("Cannot parse " + dockerUrl + " as URL: " + e.getMessage(),e);
+            host = new URI(dockerUrl).getHost();
+        } catch (URISyntaxException e) {
+            throw new MojoFailureException("Cannot parse " + dockerUrl + " as URI: " + e.getMessage(), e);
         }
+
+        project.getProperties().setProperty("docker.host.address", host == null ? "" : host);
     }
 
     // =================================================================================

--- a/src/main/java/org/jolokia/docker/maven/access/DockerAccessWithHttpClient.java
+++ b/src/main/java/org/jolokia/docker/maven/access/DockerAccessWithHttpClient.java
@@ -45,8 +45,8 @@ public class DockerAccessWithHttpClient implements DockerAccess {
      */
     public DockerAccessWithHttpClient(String apiVersion, String baseUrl, String certPath, Logger log) throws IOException {
         this.log = log;
-        this.delegate = new ApacheHttpDelegate(isSSL(baseUrl) ? certPath : null);
-        this.urlBuilder = new UrlBuilder(baseUrl, apiVersion);
+        this.delegate = ApacheHttpDelegate.create(baseUrl, isSSL(baseUrl) ? certPath : null);
+        this.urlBuilder = delegate.createUrlBuilder(baseUrl, apiVersion);
     }
 
     @Override

--- a/src/main/java/org/jolokia/docker/maven/access/http/unix/ApacheUnixSocketHttpDelegate.java
+++ b/src/main/java/org/jolokia/docker/maven/access/http/unix/ApacheUnixSocketHttpDelegate.java
@@ -1,0 +1,118 @@
+package org.jolokia.docker.maven.access.http.unix;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.UnknownHostException;
+
+import org.apache.http.config.Registry;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.conn.DnsResolver;
+import org.apache.http.conn.HttpClientConnectionManager;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.jolokia.docker.maven.access.UrlBuilder;
+import org.jolokia.docker.maven.access.http.ApacheHttpDelegate;
+
+public class ApacheUnixSocketHttpDelegate extends ApacheHttpDelegate {
+
+    private static final String UNIX_SOKKET_URI_SCHEME = "unix";
+
+    /**
+     * @see <a href="http://tools.ietf.org/html/rfc3986#section-2.2">RFC 3986 -
+     *      Uniform Resource Identifier (URI): Generic Syntax - 2.2 Reserved
+     *      Characters</a>
+     */
+    private static final String RESERVED_URI_CHARS = ":/?#[]@!$&'()/*+,;=";
+    private static final String HEX_CHARS = "0123456789ABCDEF";
+
+    public ApacheUnixSocketHttpDelegate() {
+        super(createHttpClient());
+    }
+
+    public static boolean isSchemeSupported(String baseUrl) {
+        return baseUrl.startsWith(UNIX_SOKKET_URI_SCHEME + "://");
+    }
+
+    @Override
+    public UrlBuilder createUrlBuilder(String baseUrl, String apiVersion) {
+        final String unixSocketPath = extractUnixSocketPath(baseUrl);
+        if (unixSocketPath == null) {
+            throw new IllegalArgumentException("Unsupported Base URL: " + baseUrl);
+        }
+
+        return new UrlBuilder(buildPseudoHostUrl(unixSocketPath), apiVersion);
+    }
+
+    private static CloseableHttpClient createHttpClient() {
+        final HttpClientBuilder httpBuilder = HttpClients.custom();
+        final Registry<ConnectionSocketFactory> registry = buildRegistry();
+        final DnsResolver dnsResolver = nullDnsResolver();
+        final HttpClientConnectionManager manager = new PoolingHttpClientConnectionManager(registry, dnsResolver);
+        httpBuilder.setConnectionManager(manager);
+        return httpBuilder.build();
+    }
+
+    private static Registry<ConnectionSocketFactory> buildRegistry() {
+        final RegistryBuilder<ConnectionSocketFactory> registryBuilder = RegistryBuilder.create();
+        registryBuilder.register(UNIX_SOKKET_URI_SCHEME, new UnixConnectionSocketFactory());
+        return registryBuilder.build();
+    }
+
+    private static DnsResolver nullDnsResolver() {
+        return new DnsResolver() {
+            @Override
+            public InetAddress[] resolve(final String host) throws UnknownHostException {
+                return new InetAddress[] {null};
+            }
+        };
+    }
+
+    private static String extractUnixSocketPath(String baseUrl) {
+        final URI uri = URI.create(baseUrl);
+        final String path = uri.getPath();
+        if (!UNIX_SOKKET_URI_SCHEME.equals(uri.getScheme()) || uri.getHost() != null || path == null) {
+            return null;
+        }
+
+        return path;
+    }
+
+    /**
+     * Creates a new URL using the {@value #UNIX_SOKKET_URI_SCHEME} scheme and
+     * the given path as the host component.
+     *
+     * @param   unixSocketPath  path to the UNIX Domain Socket file
+     *
+     * @return  a URL that carries {@code unixSocketPath} in its host component
+     */
+    private static String buildPseudoHostUrl(String unixSocketPath) {
+        return UNIX_SOKKET_URI_SCHEME + "://" + encodeUriPart(unixSocketPath) + ":1";
+    }
+
+    private static String encodeUriPart(String part) {
+        StringBuilder buf = null;
+
+        final int length = part.length();
+        for (int i = 0; i < length; ++i) {
+            final char c = part.charAt(i);
+
+            if (RESERVED_URI_CHARS.indexOf(c) >= 0) {
+                if (buf == null) {
+                    buf = new StringBuilder(length * 4 / 3 + 1);
+                    buf.append(part, 0, i);
+                }
+
+                buf.append('%');
+                buf.append(HEX_CHARS.charAt(c / 16));
+                buf.append(HEX_CHARS.charAt(c % 16));
+            } else if (buf != null) {
+                buf.append(c);
+            }
+        }
+
+        return buf == null ? part : buf.toString();
+    }
+}

--- a/src/main/java/org/jolokia/docker/maven/access/http/unix/UnixConnectionSocketFactory.java
+++ b/src/main/java/org/jolokia/docker/maven/access/http/unix/UnixConnectionSocketFactory.java
@@ -1,0 +1,28 @@
+package org.jolokia.docker.maven.access.http.unix;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+
+import jnr.unixsocket.UnixSocketAddress;
+
+import org.apache.http.HttpHost;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.protocol.HttpContext;
+
+final class UnixConnectionSocketFactory implements ConnectionSocketFactory {
+
+    @Override
+    public Socket createSocket(HttpContext context) throws IOException {
+        return new UnixSocket();
+    }
+
+    @Override
+    public Socket connectSocket(int connectTimeout, Socket sock, HttpHost host, InetSocketAddress remoteAddress,
+            InetSocketAddress localAddress, HttpContext context)
+            throws IOException {
+        sock.connect(new UnixSocketAddress(new File(host.getHostName())), connectTimeout);
+        return sock;
+    }
+}

--- a/src/main/java/org/jolokia/docker/maven/access/http/unix/UnixSocket.java
+++ b/src/main/java/org/jolokia/docker/maven/access/http/unix/UnixSocket.java
@@ -1,0 +1,306 @@
+package org.jolokia.docker.maven.access.http.unix;
+
+import java.io.FilterInputStream;
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.SocketException;
+
+import java.nio.channels.Channels;
+import java.nio.channels.SocketChannel;
+
+import jnr.unixsocket.UnixSocketAddress;
+import jnr.unixsocket.UnixSocketChannel;
+
+final class UnixSocket extends Socket {
+
+    private final Object connectLock = new Object();
+    private volatile boolean inputShutdown, outputShutdown;
+
+    private final UnixSocketChannel channel;
+
+    public UnixSocket() throws IOException {
+        channel = UnixSocketChannel.open();
+    }
+
+    @Override
+    public void connect(SocketAddress endpoint) throws IOException {
+        connect(endpoint, 0);
+    }
+
+    @Override
+    public void connect(SocketAddress endpoint, int timeout) throws IOException {
+        if (endpoint == null) {
+            throw new NullPointerException();
+        }
+
+        if (timeout < 0) {
+            throw new IllegalArgumentException("Timeout may not be negative: " + timeout);
+        }
+
+        if (!(endpoint instanceof UnixSocketAddress)) {
+            throw new IllegalArgumentException("Unsupported address type: " + endpoint.getClass().getName());
+        }
+
+        synchronized (connectLock) {
+            channel.connect((UnixSocketAddress) endpoint);
+        }
+    }
+
+    @Override
+    public void bind(SocketAddress bindpoint) throws IOException {
+        throw new SocketException("Bind is not supported");
+    }
+
+    @Override
+    public InetAddress getInetAddress() {
+        return null;
+    }
+
+    @Override
+    public InetAddress getLocalAddress() {
+        return null;
+    }
+
+    @Override
+    public int getPort() {
+        return -1;
+    }
+
+    @Override
+    public int getLocalPort() {
+        return -1;
+    }
+
+    @Override
+    public SocketAddress getRemoteSocketAddress() {
+        synchronized (connectLock) {
+            return channel.getRemoteSocketAddress();
+        }
+    }
+
+    @Override
+    public SocketAddress getLocalSocketAddress() {
+        synchronized (connectLock) {
+            return channel.getLocalSocketAddress();
+        }
+    }
+
+    @Override
+    public SocketChannel getChannel() {
+        return null;
+    }
+
+    @Override
+    public InputStream getInputStream() throws IOException {
+        if (!channel.isOpen()) {
+            throw new SocketException("Socket is closed");
+        }
+
+        if (!channel.isConnected()) {
+            throw new SocketException("Socket is not connected");
+        }
+
+        if (inputShutdown) {
+            throw new SocketException("Socket input is shutdown");
+        }
+
+        return new FilterInputStream(Channels.newInputStream(channel)) {
+            @Override
+            public void close() throws IOException {
+                shutdownInput();
+            }
+        };
+    }
+
+    @Override
+    public OutputStream getOutputStream() throws IOException {
+        if (!channel.isOpen()) {
+            throw new SocketException("Socket is closed");
+        }
+
+        if (!channel.isConnected()) {
+            throw new SocketException("Socket is not connected");
+        }
+
+        if (outputShutdown) {
+            throw new SocketException("Socket output is shutdown");
+        }
+
+        return new FilterOutputStream(Channels.newOutputStream(channel)) {
+            @Override
+            public void write(byte[] b, int off, int len) throws IOException {
+                out.write(b, off, len);
+            }
+
+            @Override
+            public void close() throws IOException {
+                shutdownOutput();
+            }
+        };
+    }
+
+    @Override
+    public void sendUrgentData(int data) throws IOException {
+        throw new SocketException("Urgent data not supported");
+    }
+
+    @Override
+    public void setSoTimeout(int timeout) {
+        channel.setSoTimeout(timeout);
+    }
+
+    @Override
+    public int getSoTimeout() throws SocketException {
+        return channel.getSoTimeout();
+    }
+
+    @Override
+    public void setSendBufferSize(int size) throws SocketException {
+        if (size <= 0) {
+            throw new IllegalArgumentException("Send buffer size must be positive: " + size);
+        }
+
+        if (!channel.isOpen()) {
+            throw new SocketException("Socket is closed");
+        }
+
+        // just ignore
+    }
+
+    @Override
+    public synchronized int getSendBufferSize() throws SocketException {
+        if (!channel.isOpen()) {
+            throw new SocketException("Socket is closed");
+        }
+
+        throw new UnsupportedOperationException("Getting the send buffer size is not supported");
+    }
+
+    @Override
+    public synchronized void setReceiveBufferSize(int size) throws SocketException {
+        if (size <= 0) {
+            throw new IllegalArgumentException("Receive buffer size must be positive: " + size);
+        }
+
+        if (!channel.isOpen()) {
+            throw new SocketException("Socket is closed");
+        }
+
+        // just ignore
+    }
+
+    @Override
+    public synchronized int getReceiveBufferSize() throws SocketException {
+        if (!channel.isOpen()) {
+            throw new SocketException("Socket is closed");
+        }
+
+        throw new UnsupportedOperationException("Getting the receive buffer size is not supported");
+    }
+
+    @Override
+    public void setKeepAlive(boolean on) throws SocketException {
+        channel.setKeepAlive(on);
+    }
+
+    @Override
+    public boolean getKeepAlive() throws SocketException {
+        return channel.getKeepAlive();
+    }
+
+    @Override
+    public void setTrafficClass(int tc) throws SocketException {
+        if (tc < 0 || tc > 255) {
+            throw new IllegalArgumentException("Traffic class is not in range 0 -- 255: " + tc);
+        }
+
+        if (isClosed()) {
+            throw new SocketException("Socket is closed");
+        }
+
+        // just ignore
+    }
+
+    @Override
+    public int getTrafficClass() throws SocketException {
+        throw new UnsupportedOperationException("Getting the traffic class is not supported");
+    }
+
+    @Override
+    public void setReuseAddress(boolean on) throws SocketException {
+        if (isClosed()) {
+            throw new SocketException("Socket is closed");
+        }
+
+        // just ignore
+    }
+
+    @Override
+    public boolean getReuseAddress() throws SocketException {
+        throw new UnsupportedOperationException("Getting the SO_RESUEADDR option is not supported");
+    }
+
+    @Override
+    public void close() throws IOException {
+        channel.close();
+        inputShutdown = true;
+        outputShutdown = true;
+    }
+
+    @Override
+    public void shutdownInput() throws IOException {
+        channel.shutdownInput();
+        inputShutdown = true;
+    }
+
+    @Override
+    public void shutdownOutput() throws IOException {
+        channel.shutdownOutput();
+        outputShutdown = true;
+    }
+
+    @Override
+    public String toString() {
+        if (isConnected()) {
+            return "UnixSocket[addr=" + channel.getRemoteSocketAddress() + ']';
+        }
+
+        return "UnixSocket[unconnected]";
+    }
+
+    @Override
+    public boolean isConnected() {
+        return channel.isConnected();
+    }
+
+    @Override
+    public boolean isBound() {
+        return false;
+    }
+
+    @Override
+    public boolean isClosed() {
+        return !channel.isOpen();
+    }
+
+    @Override
+    public boolean isInputShutdown() {
+        return inputShutdown;
+    }
+
+    @Override
+    public boolean isOutputShutdown() {
+        return outputShutdown;
+    }
+
+    @Override
+    public void setPerformancePreferences(int connectionTime, int latency, int bandwidth) {
+        // no-op
+    }
+}


### PR DESCRIPTION
This is my draft to a solution for #148. The same technique is used by the Spotify plugin. No obscure packaging involved.


  * Use jnr-unixsocket for native OS-level access
  * Use a pseudo socket class that mimics a Java network socket and delegates to the jnr channel where applicable
  * Provide a special ApacheUnixSocketHttpDelegate that enables the Apache HTTP client to use that pseudo socket for HTTP communication