### PR TITLE
Convert host machine path to virtual machine path for those who use boot2docker

### DIFF
--- a/src/main/java/org/jolokia/docker/maven/access/ContainerHostConfig.java
+++ b/src/main/java/org/jolokia/docker/maven/access/ContainerHostConfig.java
@@ -17,6 +17,7 @@ public class ContainerHostConfig {
             JSONArray binds = new JSONArray();
 
             for (String volume : bind) {
+                volume = volume.replace("\\", "/").replaceAll("^C:", "/c");
                 if (volume.contains(":")) {
                     binds.put(volume);
                 }


### PR DESCRIPTION
Hacky workaround like this: https://github.com/boot2docker/boot2docker/blob/1bf1671c0f5c103ac4e2229b96a21a04b6d99043/rootfs/rootfs/etc/rc.d/automount-shares#L34
Pros: now you can use the variable ${project.build.directory} in run.volumes.bind.volume