### PR TITLE
wait command fails due to empty data being returned from docker logs

### DIFF
--- a/src/main/java/org/jolokia/docker/maven/access/log/LogRequestor.java
+++ b/src/main/java/org/jolokia/docker/maven/access/log/LogRequestor.java
@@ -29,6 +29,7 @@ import org.jolokia.docker.maven.access.DockerAccessException;
 import org.jolokia.docker.maven.access.UrlBuilder;
 import org.jolokia.docker.maven.util.Timestamp;
 
+import edu.emory.mathcs.backport.java.util.Arrays;
 import static java.lang.Math.min;
 import static org.jolokia.docker.maven.access.util.RequestUtil.newGet;
 
@@ -106,6 +107,9 @@ public class LogRequestor extends Thread implements LogGetHandle {
             while (IOUtils.read(is, headBuf, 0, 8) > 0) {
                 int type = headBuf[0];
                 int declaredLength = extractLength(headBuf);
+                if(declaredLength == 0) {
+                    continue;
+                }
                 byte[] buf = new byte[declaredLength];
                 int len = IOUtils.read(is, buf, 0, declaredLength);
                 if (len < 1) {
@@ -127,6 +131,15 @@ public class LogRequestor extends Thread implements LogGetHandle {
         } catch (LogCallback.DoneException e) {
             // Can be thrown by a log callback which indicates that we are done.
             finish();
+        }
+    }
+
+    private void sleep() {
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
         }
     }
 

--- a/src/main/java/org/jolokia/docker/maven/access/log/LogRequestor.java
+++ b/src/main/java/org/jolokia/docker/maven/access/log/LogRequestor.java
@@ -29,7 +29,6 @@ import org.jolokia.docker.maven.access.DockerAccessException;
 import org.jolokia.docker.maven.access.UrlBuilder;
 import org.jolokia.docker.maven.util.Timestamp;
 
-import edu.emory.mathcs.backport.java.util.Arrays;
 import static java.lang.Math.min;
 import static org.jolokia.docker.maven.access.util.RequestUtil.newGet;
 
@@ -131,15 +130,6 @@ public class LogRequestor extends Thread implements LogGetHandle {
         } catch (LogCallback.DoneException e) {
             // Can be thrown by a log callback which indicates that we are done.
             finish();
-        }
-    }
-
-    private void sleep() {
-        try {
-            Thread.sleep(1000);
-        } catch (InterruptedException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
         }
     }
 


### PR DESCRIPTION
After upgrading to Docker 1.7 we started to have problems with wait command which was timing out as it was giving up reading from logs due to first two reads in header not containing expected data (the declaredLength being 0). PR fixes this issue.