### PR TITLE
docker:build - add support for WORKDIR

### DIFF
--- a/src/main/java/org/jolokia/docker/maven/assembly/DockerAssemblyManager.java
+++ b/src/main/java/org/jolokia/docker/maven/assembly/DockerAssemblyManager.java
@@ -148,6 +148,9 @@ public class DockerAssemblyManager {
         if (buildConfig.getMaintainer() != null) {
             builder.maintainer(buildConfig.getMaintainer());
         }
+        if (buildConfig.getWorkdir() != null) {
+            builder.workdir(buildConfig.getWorkdir());
+        }
         if (assemblyConfig != null) {
             builder.add("maven", "")
                    .basedir(assemblyConfig.getBasedir())

--- a/src/main/java/org/jolokia/docker/maven/assembly/DockerFileBuilder.java
+++ b/src/main/java/org/jolokia/docker/maven/assembly/DockerFileBuilder.java
@@ -45,7 +45,7 @@ public class DockerFileBuilder {
     private List<AddEntry> addEntries = new ArrayList<>();
 
     // list of ports to expose and environments to use
-    private List<Integer> ports = new ArrayList<>();
+    private List<String> ports = new ArrayList<>();
     private Map<String,String> envEntries = new HashMap<>();
     
     // exposed volumes
@@ -141,7 +141,7 @@ public class DockerFileBuilder {
     private void addPorts(StringBuilder b) {
         if (ports.size() > 0) {
             b.append("EXPOSE");
-            for (Integer port : ports) {
+            for (String port : ports) {
                 b.append(" ").append(port);
             }
             b.append("\n");
@@ -222,7 +222,7 @@ public class DockerFileBuilder {
         if (ports != null) {
             for (String port : ports) {
                 if (port != null) {
-                    this.ports.add(Integer.parseInt(port));
+                    this.ports.add(port);
                 }
             }
         }

--- a/src/main/java/org/jolokia/docker/maven/assembly/DockerFileBuilder.java
+++ b/src/main/java/org/jolokia/docker/maven/assembly/DockerFileBuilder.java
@@ -25,6 +25,9 @@ public class DockerFileBuilder {
     // Maintainer of this image
     private String maintainer = "docker-maven-plugin@jolokia.org";
 
+    // Workdir
+    private String workdir = null;
+
     // Basedir to be export
     private String basedir = "/maven";
 
@@ -73,11 +76,11 @@ public class DockerFileBuilder {
         
         b.append("FROM ").append(baseImage != null ? baseImage : DockerAssemblyManager.DEFAULT_DATA_BASE_IMAGE).append("\n");
         b.append("MAINTAINER ").append(maintainer).append("\n");
-
         addEnv(b);
         addPorts(b);
         addVolumes(b);
         addEntries(b);
+        if (workdir != null) b.append("WORKDIR ").append(workdir).append("\n");
         addCmd(b);
         addEntryPoint(b);
 
@@ -178,6 +181,11 @@ public class DockerFileBuilder {
 
     public DockerFileBuilder maintainer(String maintainer) {
         this.maintainer = maintainer;
+        return this;
+    }
+
+    public DockerFileBuilder workdir(String workdir) {
+        this.workdir = workdir;
         return this;
     }
 

--- a/src/main/java/org/jolokia/docker/maven/config/BuildImageConfiguration.java
+++ b/src/main/java/org/jolokia/docker/maven/config/BuildImageConfiguration.java
@@ -86,6 +86,10 @@ public class BuildImageConfiguration {
         return maintainer;
     }
 
+    public String getWorkdir() {
+        return workdir;
+    }
+
     public AssemblyConfiguration getAssemblyConfiguration() {
         return assembly;
     }

--- a/src/main/java/org/jolokia/docker/maven/config/BuildImageConfiguration.java
+++ b/src/main/java/org/jolokia/docker/maven/config/BuildImageConfiguration.java
@@ -60,6 +60,11 @@ public class BuildImageConfiguration {
     /**
      * @parameter
      */
+    private String workdir;
+
+    /**
+     * @parameter
+     */
     private Arguments cmd;
 
     /**
@@ -129,6 +134,11 @@ public class BuildImageConfiguration {
 
         public Builder maintainer(String maintainer) {
             config.maintainer = maintainer;
+            return this;
+        }
+
+        public Builder workdir(String workdir) {
+            config.workdir = workdir;
             return this;
         }
 

--- a/src/main/java/org/jolokia/docker/maven/config/handler/property/ConfigKey.java
+++ b/src/main/java/org/jolokia/docker/maven/config/handler/property/ConfigKey.java
@@ -59,6 +59,7 @@ public enum ConfigKey {
     VOLUMES,
     TAGS,
     MAINTAINER,
+    WORKDIR,
     VOLUMES_FROM,
     WAIT_LOG("wait.log"),
     WAIT_TIME("wait.time"),

--- a/src/main/java/org/jolokia/docker/maven/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/org/jolokia/docker/maven/config/handler/property/PropertyConfigHandler.java
@@ -66,6 +66,7 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
                 .volumes(listWithPrefix(prefix, VOLUMES, properties))
                 .tags(listWithPrefix(prefix, TAGS, properties))
                 .maintainer(withPrefix(prefix, MAINTAINER, properties))
+                .workdir(withPrefix(prefix, WORKDIR, properties))
                 .build();
     }
 


### PR DESCRIPTION
This is a pretty straightforward feature addition of the WORKDIR Dockerfile parameter:
https://docs.docker.com/reference/builder/#workdir
Would it be possible to pull?