### PR TITLE
fix #211 - wait url can contain user information

### DIFF
--- a/src/main/java/org/jolokia/docker/maven/StartMojo.java
+++ b/src/main/java/org/jolokia/docker/maven/StartMojo.java
@@ -114,7 +114,7 @@ public class StartMojo extends AbstractDockerMojo {
             ArrayList<String> logOut = new ArrayList<>();
             if (wait.getUrl() != null) {
                 String waitUrl = StrSubstitutor.replace(wait.getUrl(), projectProperties);
-                checkers.add(new WaitUtil.HttpPingChecker(waitUrl));
+                checkers.add(new WaitUtil.HttpPingChecker(waitUrl, log));
                 logOut.add("on url " + waitUrl);
             }
             if (wait.getLog() != null) {

--- a/src/main/java/org/jolokia/docker/maven/util/WaitUtil.java
+++ b/src/main/java/org/jolokia/docker/maven/util/WaitUtil.java
@@ -1,9 +1,14 @@
 package org.jolokia.docker.maven.util;
 
 import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.net.URL;
 import java.util.concurrent.TimeoutException;
+
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpHead;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 
 /**
  * @author roland
@@ -75,28 +80,53 @@ public class WaitUtil {
     public static class HttpPingChecker implements WaitChecker {
 
         private String url;
+        private Logger log;
 
         /**
          * Ping the given URL
          *
          * @param url URL to check
+         * @param log Mojo logger
          * @param timeout
          */
-        public HttpPingChecker(String url) {
+        public HttpPingChecker(String url, Logger log) {
             this.url = url;
+            this.log = log;
         }
 
         @Override
         public boolean check() {
             try {
-                HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
-                connection.setConnectTimeout(HTTP_PING_TIMEOUT);
-                connection.setReadTimeout(HTTP_PING_TIMEOUT);
-                connection.setRequestMethod("HEAD");
-                int responseCode = connection.getResponseCode();
-                return (responseCode >= 200 && responseCode <= 399);
-            } catch (IOException exception) {
+                return ping();
+            } catch (ClientProtocolException exception) {
+                log.debug(String.format("wait url '%s' exception: %s", url, exception.getMessage()));
                 return false;
+            } catch (IOException exception) {
+                log.debug(String.format("wait url '%s' exception: %s", url, exception.getMessage()));
+                return false;
+            }
+        }
+
+        private boolean ping() throws IOException, ClientProtocolException {
+            RequestConfig requestConfig = RequestConfig.custom() //
+                    .setSocketTimeout(HTTP_PING_TIMEOUT) //
+                    .setConnectTimeout(HTTP_PING_TIMEOUT) //
+                    .setConnectionRequestTimeout(HTTP_PING_TIMEOUT) //
+                    .build();
+            CloseableHttpClient httpClient = HttpClientBuilder.create() //
+                    .setDefaultRequestConfig(requestConfig) //
+                    .build();
+            try {
+                CloseableHttpResponse response = httpClient.execute(new HttpHead(url));
+                try {
+                    int responseCode = response.getStatusLine().getStatusCode();
+                    log.debug(String.format("wait url '%s' response code: %s", url, responseCode));
+                    return (responseCode >= 200 && responseCode <= 399);
+                } finally {
+                    response.close();
+                }
+            } finally {
+                httpClient.close();
             }
         }
 

--- a/src/test/java/org/jolokia/docker/maven/util/WaitUtilTest.java
+++ b/src/test/java/org/jolokia/docker/maven/util/WaitUtilTest.java
@@ -6,6 +6,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeoutException;
 
 import com.sun.net.httpserver.*;
+
+import mockit.Mocked;
+
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -22,10 +25,11 @@ public class WaitUtilTest {
     static int port;
     static String httpPingUrl;
 
+    @Mocked Logger log;
 
     @Test(expected = TimeoutException.class)
     public void httpFail() throws TimeoutException {
-        WaitUtil.HttpPingChecker checker = new WaitUtil.HttpPingChecker(httpPingUrl);
+        WaitUtil.HttpPingChecker checker = new WaitUtil.HttpPingChecker(httpPingUrl, log);
         long waited = WaitUtil.wait(500,checker);
     }
 
@@ -33,7 +37,11 @@ public class WaitUtilTest {
     public void httpSuccess() throws TimeoutException {
         server.start();
         System.out.println("Check URL " + httpPingUrl);
-        WaitUtil.HttpPingChecker checker = new WaitUtil.HttpPingChecker(httpPingUrl);
+
+        // preload - first time use almost always lasts much longer (i'm assuming its http client initialization behavior)
+        WaitUtil.wait(700,new WaitUtil.HttpPingChecker(httpPingUrl, log));
+
+        WaitUtil.HttpPingChecker checker = new WaitUtil.HttpPingChecker(httpPingUrl, log);
         long waited = WaitUtil.wait(700,checker);
         assertTrue("Waited longer than 500ms: " + waited,waited < 700);
         server.stop(10);


### PR DESCRIPTION
Replace ping implementation from java.net.HttpURLConnection
to Apache HttpClient. Generate ping errors diagnostics info
when maven debug level is active.
Fixes #211.