### PR TITLE
Ignore zero-length log frames

### DIFF
--- a/src/main/java/org/jolokia/docker/maven/access/log/LogRequestor.java
+++ b/src/main/java/org/jolokia/docker/maven/access/log/LogRequestor.java
@@ -111,7 +111,9 @@ public class LogRequestor extends Thread implements LogGetHandle {
                 }
                 byte[] buf = new byte[declaredLength];
                 int len = IOUtils.read(is, buf, 0, declaredLength);
-                if (len < 1) {
+                if (len == 0) {
+                    continue;
+                } else if (len < 0) {
                     callback.error("Invalid log format: Couldn't read " + declaredLength + " bytes from stream");
                     finish();
                     return;


### PR DESCRIPTION
Sometimes the log watch gives you a zero length frame.  I have no idea why,
but ignoring it allows it to work fine, and is better than bailing...