### PR TITLE
If the StartMojo fails, stop all started containers

### DIFF
--- a/src/main/java/org/jolokia/docker/maven/StartMojo.java
+++ b/src/main/java/org/jolokia/docker/maven/StartMojo.java
@@ -60,6 +60,8 @@ public class StartMojo extends AbstractDockerMojo {
         getPluginContext().put(CONTEXT_KEY_START_CALLED, true);
 
         LogDispatcher dispatcher = getLogDispatcher(dockerAccess);
+
+        boolean success = false;
         try {
             for (StartOrderResolver.Resolvable resolvable : runService.getImagesConfigsInOrder(getImages())) {
                 final ImageConfiguration imageConfig = (ImageConfiguration) resolvable;
@@ -90,8 +92,13 @@ public class StartMojo extends AbstractDockerMojo {
                 runService.addShutdownHookForStoppingContainers(dockerAccess,keepContainer,removeVolumes);
                 wait();
             }
+            success = true;
         } catch (InterruptedException e) {
             log.warn("Interrupted");
+        } finally {
+            if (!success) {
+                runService.stopStartedContainers(dockerAccess, keepContainer, removeVolumes);
+            }
         }
     }
 

--- a/src/main/java/org/jolokia/docker/maven/StartMojo.java
+++ b/src/main/java/org/jolokia/docker/maven/StartMojo.java
@@ -95,6 +95,8 @@ public class StartMojo extends AbstractDockerMojo {
             success = true;
         } catch (InterruptedException e) {
             log.warn("Interrupted");
+            Thread.currentThread().interrupt();
+            throw new MojoExecutionException("interrupted", e);
         } finally {
             if (!success) {
                 runService.stopStartedContainers(dockerAccess, keepContainer, removeVolumes);


### PR DESCRIPTION
We're about to fail the build anyway, so let's not leave heavyweight resources lying around.  ( HubSpot/Singularity#607 )