### PR TITLE
- Add, support on the Handlers for reading the cmds section.

### DIFF
--- a/doc/manual.md
+++ b/doc/manual.md
@@ -256,6 +256,8 @@ of an image configuration. The available subelements are
 * **tags** contains a list of additional `tag` elements with which an
   image is to be tagged after the build.
 * **maintainer** specifies the author (MAINTAINER) field for the generated image
+* **runCmds** specifies commands to be run during the building process. It contains **runCmd** Elements 
+  which are passed to bash. The **workdir**-Attribute applies before the command executions.
 
 From this configuration this Plugin creates an in-memory Dockerfile,
 copies over the assembled files and calls the Docker daemon via its

--- a/src/main/java/org/jolokia/docker/maven/assembly/DockerAssemblyManager.java
+++ b/src/main/java/org/jolokia/docker/maven/assembly/DockerAssemblyManager.java
@@ -22,7 +22,10 @@ import org.codehaus.plexus.archiver.util.DefaultArchivedFileSet;
 import org.codehaus.plexus.archiver.util.DefaultFileSet;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
-import org.jolokia.docker.maven.config.*;
+import org.jolokia.docker.maven.config.Arguments;
+import org.jolokia.docker.maven.config.AssemblyConfiguration;
+import org.jolokia.docker.maven.config.AssemblyMode;
+import org.jolokia.docker.maven.config.BuildImageConfiguration;
 import org.jolokia.docker.maven.util.EnvUtil;
 import org.jolokia.docker.maven.util.MojoParameters;
 
@@ -36,7 +39,7 @@ import org.jolokia.docker.maven.util.MojoParameters;
 @Component(role = DockerAssemblyManager.class)
 public class DockerAssemblyManager {
 
-    public static final String DEFAULT_DATA_BASE_IMAGE = "busybox:latest";;
+    public static final String DEFAULT_DATA_BASE_IMAGE = "busybox:latest";
 
     @Requirement
     private AssemblyArchiver assemblyArchiver;
@@ -171,6 +174,7 @@ public class DockerAssemblyManager {
                         .env(buildConfig.getEnv())
                         .labels(buildConfig.getLabels())
                         .expose(buildConfig.getPorts())
+                        .runCommands(buildConfig.getRunCmds())
                         .volumes(buildConfig.getVolumes());
         if (buildConfig.getMaintainer() != null) {
             builder.maintainer(buildConfig.getMaintainer());

--- a/src/main/java/org/jolokia/docker/maven/assembly/DockerFileBuilder.java
+++ b/src/main/java/org/jolokia/docker/maven/assembly/DockerFileBuilder.java
@@ -47,7 +47,11 @@ public class DockerFileBuilder {
     // list of ports to expose and environments to use
     private List<Integer> ports = new ArrayList<>();
 
-    // environment
+    // list of RUN Commands to run along with image build see issue #191 on github
+    private List<String> runcmds = new ArrayList<>();
+
+// environment
+
     private Map<String,String> envEntries = new HashMap<>();
 
     // image labels
@@ -79,14 +83,18 @@ public class DockerFileBuilder {
 
         StringBuilder b = new StringBuilder();
         
-        b.append("FROM ").append(baseImage != null ? baseImage : DockerAssemblyManager.DEFAULT_DATA_BASE_IMAGE).append("\n");
-        b.append("MAINTAINER ").append(maintainer).append("\n");
+        b.append(DockerFileDictionary.FROM.name()).append(" ").append(baseImage != null ? baseImage : DockerAssemblyManager.DEFAULT_DATA_BASE_IMAGE).append("\n");
+        b.append(DockerFileDictionary.MAINTAINER.name()).append(" ").append(maintainer).append("\n");
+
         addEnv(b);
         addLabels(b);
         addPorts(b);
+
         addVolumes(b);
         addEntries(b);
         addWorkdir(b);
+        //RUN COMMANDS See https://docs.docker.com/reference/builder/#run
+        addRunCmds(b);
         addCmd(b);
         addEntryPoint(b);
 
@@ -171,13 +179,19 @@ public class DockerFileBuilder {
 
     private void addPorts(StringBuilder b) {
         if (ports.size() > 0) {
-            b.append("EXPOSE");
+            b.append(DockerFileDictionary.EXPOSE.name());
             for (Integer port : ports) {
                 b.append(" ").append(port);
             }
             b.append("\n");
         }
     }
+
+	private void addRunCmds(StringBuilder b) {
+		for (String runCmd : runcmds) {
+			b.append(DockerFileDictionary.RUN.name()).append(" ").append(runCmd).append("\n");
+		}
+	}
 
     private void addVolumes(StringBuilder b) {
         if (exportBasedir != null ? exportBasedir : baseImage == null) {
@@ -258,6 +272,22 @@ public class DockerFileBuilder {
                     } catch (NumberFormatException exp) {
                         throw new IllegalArgumentException("Non numeric port " + port + " specified in port mapping",exp);
                     }
+                }
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Adds the RUN Commands within the build image section
+     * @param runCmds
+     * @return
+     */
+    public DockerFileBuilder runCommands(List<String> runCmds) {
+        if (runCmds != null) {
+            for (String cmd : runCmds) {
+                if (!StringUtils.isEmpty(cmd)) {
+                    this.runcmds.add(cmd);
                 }
             }
         }

--- a/src/main/java/org/jolokia/docker/maven/assembly/DockerFileDictionary.java
+++ b/src/main/java/org/jolokia/docker/maven/assembly/DockerFileDictionary.java
@@ -1,0 +1,16 @@
+package org.jolokia.docker.maven.assembly;
+
+/**
+ * Fields for  a dockerfile
+ * @author Paris Apostolopoulos <javapapo@mac.com>
+ * @author Christian Fischer <sw-dev@computerlyrik.de>
+ * @since 13.06.05
+ */
+public enum DockerFileDictionary {
+    MAINTAINER,
+    EXPOSE,
+    FROM,
+    RUN,
+    COPY
+
+}

--- a/src/main/java/org/jolokia/docker/maven/config/BuildImageConfiguration.java
+++ b/src/main/java/org/jolokia/docker/maven/config/BuildImageConfiguration.java
@@ -32,6 +32,13 @@ public class BuildImageConfiguration {
     private List<String> ports;
 
     /**
+     * RUN Commands within Build/Image
+     * @parameter
+     */
+    private List<String> runCmds;
+
+
+    /**
      * @paramter
      */
     private List<String> volumes;
@@ -132,6 +139,9 @@ public class BuildImageConfiguration {
         return entryPoint;
     }
 
+    public List<String> getRunCmds() {
+        return runCmds;
+    }
 
     public static class Builder {
         private final BuildImageConfiguration config = new BuildImageConfiguration();
@@ -163,6 +173,15 @@ public class BuildImageConfiguration {
         
         public Builder ports(List<String> ports) {
             config.ports = ports;
+            return this;
+        }
+
+        public Builder runCmds(List<String> theCmds) {
+            if (config.runCmds == null) {
+                config.runCmds = new ArrayList<String>();
+            }
+            else
+            	config.runCmds = theCmds;
             return this;
         }
         

--- a/src/main/java/org/jolokia/docker/maven/config/handler/property/ConfigKey.java
+++ b/src/main/java/org/jolokia/docker/maven/config/handler/property/ConfigKey.java
@@ -53,6 +53,7 @@ public enum ConfigKey {
     NAMING_STRATEGY,
     PORT_PROPERTY_FILE,
     PORTS,
+    RUNCMDS,
     PRIVILEGED,
     REGISTRY,
     RESTART_POLICY_NAME("restartPolicy.name"),

--- a/src/main/java/org/jolokia/docker/maven/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/org/jolokia/docker/maven/config/handler/property/PropertyConfigHandler.java
@@ -64,6 +64,7 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
                 .env(mapWithPrefix(prefix, ENV, properties))
                 .labels(mapWithPrefix(prefix,LABELS,properties))
                 .ports(extractPortValues(prefix, properties))
+                .runCmds(extractRunCommands(prefix,properties))
                 .from(withPrefix(prefix, FROM, properties))
                 .registry(withPrefix(prefix, REGISTRY, properties))
                 .volumes(listWithPrefix(prefix, VOLUMES, properties))
@@ -134,6 +135,16 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
         List<String[]> parsedPorts = EnvUtil.splitOnLastColon(ports);
         for (String[] port : parsedPorts) {
             ret.add(port[1]);
+        }
+        return ret;
+    }
+
+
+    private List<String> extractRunCommands(String prefix, Properties properties) {
+        List<String> ret = new ArrayList<>();
+        List<String> cmds = listWithPrefix(prefix, RUNCMDS, properties);
+        if (cmds == null) {
+            return null;
         }
         return ret;
     }

--- a/src/test/java/org/jolokia/docker/maven/assembly/DockerFileBuilderTest.java
+++ b/src/test/java/org/jolokia/docker/maven/assembly/DockerFileBuilderTest.java
@@ -26,8 +26,9 @@ public class DockerFileBuilderTest {
                 .maintainer("maintainer@example.com")
                 .workdir("/tmp")
                 .labels(ImmutableMap.of("com.acme.foobar", "How are \"you\" ?"))
-                .volumes(Collections.singletonList("/vol1")).content();
-
+                .volumes(Collections.singletonList("/vol1"))
+                .runCommands(Arrays.asList("echo something","echo second"))
+                .content();
         String expected = loadFile("docker/Dockerfile.test");
         assertEquals(expected, stripCR(dockerfileContent));
     }

--- a/src/test/resources/docker/Dockerfile.test
+++ b/src/test/resources/docker/Dockerfile.test
@@ -3,6 +3,8 @@ MAINTAINER maintainer@example.com
 ENV foo=bar
 LABEL com.acme.foobar="How are \"you\" ?"
 EXPOSE 8080
+RUN echo something
+RUN echo second
 VOLUME ["/vol1"]
 COPY /src /export/dest
 WORKDIR /tmp


### PR DESCRIPTION
- minor changes on using an ENUM on some 'reserved' words for the DockerFile dictionary.

Signed-off-by: Paris Apostolopoulos <javapapo@mac.com>

moved running of commands further to the end to work inside workdir - order matters here

added howto use to manual

fixed some issues referenced at https://github.com/rhuss/docker-maven-plugin/pull/215

fixed some issues referenced at https://github.com/rhuss/docker-maven-plugin/pull/215

removed unused code
Signed-off-by: Christian Fischer <sw-dev@computerlyrik.de>

Cleanup of https://github.com/rhuss/docker-maven-plugin/pull/215