### PR TITLE
allow linking / volumesFrom external containers

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -4,6 +4,8 @@
   - Allow autoPull to be forced on docker:build and docker:start (#96)
   - Respect username when looking up credentials for a Docker registry (#174)
   - Add "force=1" to push for Fedora/CentOs images allowing to push to docker hub
+  - Allow linking to external containers (#195)
+  - Allow volume mounting from external containers (#73)
   
 Note that the default registry has been changed to `docker.io` as docker hub doesn't use 
 `registry.hub.docker.com` as the default registry and refused to authenticate against this 

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -702,6 +702,9 @@ DB_PORT_5432_TCP_PORT=5432
 DB_PORT_5432_TCP_ADDR=172.17.0.5
 ```
 
+If you wish to link to existing containers not managed by the plugin, you may do so by specifying the container name
+obtained via `docker ps` in the configuration.
+
 ##### Volume binding
 
 A container can bind (or "mount") volumes from various source when starting up: Either from a directory of
@@ -743,6 +746,9 @@ should even work for boot2docker:
   </bind>
 </volumes>
 ````
+
+If you wish to mount volumes from an existing container not managed by the plugin, you may do by specifying the container name
+obtained via `docker ps` in the configuration.
 
 ##### Container restart policy
 

--- a/src/main/java/org/jolokia/docker/maven/LogsMojo.java
+++ b/src/main/java/org/jolokia/docker/maven/LogsMojo.java
@@ -3,9 +3,10 @@ package org.jolokia.docker.maven;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.jolokia.docker.maven.access.DockerAccess;
 import org.jolokia.docker.maven.access.DockerAccessException;
-import org.jolokia.docker.maven.config.*;
+import org.jolokia.docker.maven.config.ImageConfiguration;
 import org.jolokia.docker.maven.log.LogDispatcher;
 import org.jolokia.docker.maven.model.Container;
+import org.jolokia.docker.maven.service.QueryService;
 
 
 /**
@@ -36,6 +37,7 @@ public class LogsMojo extends AbstractDockerMojo {
 
     @Override
     protected void executeInternal(DockerAccess access) throws MojoExecutionException, DockerAccessException {
+        QueryService queryService = serviceFactory.getQueryService(access, log);
         LogDispatcher logDispatcher = getLogDispatcher(access);
 
         for (ImageConfiguration image : getImages()) {

--- a/src/main/java/org/jolokia/docker/maven/LogsMojo.java
+++ b/src/main/java/org/jolokia/docker/maven/LogsMojo.java
@@ -5,6 +5,8 @@ import org.jolokia.docker.maven.access.DockerAccess;
 import org.jolokia.docker.maven.access.DockerAccessException;
 import org.jolokia.docker.maven.config.*;
 import org.jolokia.docker.maven.log.LogDispatcher;
+import org.jolokia.docker.maven.model.Container;
+
 
 /**
  * Mojo for printing logs of a container. By default the logs of all containers are shown interwoven
@@ -32,19 +34,19 @@ public class LogsMojo extends AbstractDockerMojo {
     /** @parameter property = "docker.logAll" default-value = "false" */
     private boolean logAll;
 
+    @Override
     protected void executeInternal(DockerAccess access) throws MojoExecutionException, DockerAccessException {
-
         LogDispatcher logDispatcher = getLogDispatcher(access);
 
         for (ImageConfiguration image : getImages()) {
             String imageName = image.getName();
             if (logAll) {
-                for (String container : access.getContainersForImage(imageName)) {
-                    doLogging(logDispatcher, image, container);
+                for (Container container : queryService.getContainersForImage(imageName)) {
+                    doLogging(logDispatcher, image, container.getId());
                 }
             } else {
-                String container = access.getNewestImageForContainer(imageName);
-                doLogging(logDispatcher, image, container);
+                Container container = queryService.getLatestContainerForImage(imageName);
+                doLogging(logDispatcher, image, container.getId());
             }
         }
         if (follow) {

--- a/src/main/java/org/jolokia/docker/maven/RemoveMojo.java
+++ b/src/main/java/org/jolokia/docker/maven/RemoveMojo.java
@@ -38,18 +38,19 @@ import org.jolokia.docker.maven.config.*;
 
 public class RemoveMojo extends AbstractDockerMojo {
 
-    // Whether all configured images should be removed
     /**
+     * Should all configured images should be removed?
+     * 
      * @parameter property = "docker.removeAll" default-value = "false"
      */
     private boolean removeAll;
-
+    
     @Override
     protected void executeInternal(DockerAccess dockerAccess) throws DockerAccessException {
         for (ImageConfiguration image : getImages()) {
             String name = image.getName();
             if (removeAll || image.isDataImage()) {
-                if (dockerAccess.hasImage(name)) {
+                if (queryService.hasImage(name)) {
                     if (dockerAccess.removeImage(name,true)) {
                         log.info(image.getDescription() + ": Remove");
                     }

--- a/src/main/java/org/jolokia/docker/maven/RemoveMojo.java
+++ b/src/main/java/org/jolokia/docker/maven/RemoveMojo.java
@@ -18,6 +18,7 @@ package org.jolokia.docker.maven;/*
 import org.jolokia.docker.maven.access.DockerAccess;
 import org.jolokia.docker.maven.access.DockerAccessException;
 import org.jolokia.docker.maven.config.*;
+import org.jolokia.docker.maven.service.QueryService;
 
 /**
  * Mojo for removing images. By default only data images are removed. Data images are
@@ -47,6 +48,8 @@ public class RemoveMojo extends AbstractDockerMojo {
     
     @Override
     protected void executeInternal(DockerAccess dockerAccess) throws DockerAccessException {
+        QueryService queryService = serviceFactory.getQueryService(dockerAccess, log);
+        
         for (ImageConfiguration image : getImages()) {
             String name = image.getName();
             if (removeAll || image.isDataImage()) {

--- a/src/main/java/org/jolokia/docker/maven/StartMojo.java
+++ b/src/main/java/org/jolokia/docker/maven/StartMojo.java
@@ -43,16 +43,7 @@ public class StartMojo extends AbstractDockerMojo {
      * @parameter property = "docker.follow" default-value = "false"
      */
     protected boolean follow;
-
-    /** @component **/
-    protected RunService runService;
-
-    @Override
-    protected void initializeServices(DockerAccess access, QueryService queryService, Logger log) {
-        super.initializeServices(access, queryService, log);
-        runService.initialize(access, queryService, log);
-    }
-
+ 
     /**
      * {@inheritDoc}
      */
@@ -60,6 +51,9 @@ public class StartMojo extends AbstractDockerMojo {
     public synchronized void executeInternal(final DockerAccess dockerAccess) throws DockerAccessException, MojoExecutionException {
         getPluginContext().put(CONTEXT_KEY_START_CALLED, true);
 
+        QueryService queryService = serviceFactory.getQueryService(dockerAccess, log);
+        RunService runService = serviceFactory.getRunService(dockerAccess, log);
+        
         LogDispatcher dispatcher = getLogDispatcher(dockerAccess);
         try {
             for (StartOrderResolver.Resolvable resolvable : runService.getImagesConfigsInOrder(queryService, getImages())) {

--- a/src/main/java/org/jolokia/docker/maven/StopMojo.java
+++ b/src/main/java/org/jolokia/docker/maven/StopMojo.java
@@ -5,6 +5,8 @@ import org.jolokia.docker.maven.access.DockerAccess;
 import org.jolokia.docker.maven.access.DockerAccessException;
 import org.jolokia.docker.maven.config.ImageConfiguration;
 import org.jolokia.docker.maven.log.LogDispatcher;
+import org.jolokia.docker.maven.model.Container;
+import org.jolokia.docker.maven.service.QueryService;
 import org.jolokia.docker.maven.service.RunService;
 import org.jolokia.docker.maven.util.Logger;
 
@@ -34,10 +36,11 @@ public class StopMojo extends AbstractDockerMojo {
 
     /** @component */
     private RunService runService;
-
+    
     @Override
-    protected void initLog(Logger log) {
-        runService.initLog(log);
+    protected void initializeServices(DockerAccess access, QueryService queryService, Logger log) {
+        super.initializeServices(access, queryService, log);
+        runService.initialize(access, queryService, log);
     }
 
     @Override
@@ -49,12 +52,12 @@ public class StopMojo extends AbstractDockerMojo {
                 // Called directly ....
                 for (ImageConfiguration image : getImages()) {
                     String imageName = image.getName();
-                    for (String container : access.getContainersForImage(imageName)) {
-                        runService.stopContainer(access, image, container, keepContainer, removeVolumes);
+                    for (Container container : queryService.getContainersForImage(imageName)) {
+                        runService.stopContainer(image, container.getId(), keepContainer, removeVolumes);
                     }
                 }
             } else {
-                runService.stopStartedContainers(access, keepContainer, removeVolumes);
+                runService.stopStartedContainers(keepContainer, removeVolumes);
             }
         }
 

--- a/src/main/java/org/jolokia/docker/maven/StopMojo.java
+++ b/src/main/java/org/jolokia/docker/maven/StopMojo.java
@@ -8,7 +8,6 @@ import org.jolokia.docker.maven.log.LogDispatcher;
 import org.jolokia.docker.maven.model.Container;
 import org.jolokia.docker.maven.service.QueryService;
 import org.jolokia.docker.maven.service.RunService;
-import org.jolokia.docker.maven.util.Logger;
 
 /**
  * Mojo for stopping containers. If called together with <code>docker:start</code> (i.e.
@@ -34,19 +33,14 @@ public class StopMojo extends AbstractDockerMojo {
      */
     private boolean keepRunning;
 
-    /** @component */
-    private RunService runService;
-    
-    @Override
-    protected void initializeServices(DockerAccess access, QueryService queryService, Logger log) {
-        super.initializeServices(access, queryService, log);
-        runService.initialize(access, queryService, log);
-    }
-
     @Override
     protected void executeInternal(DockerAccess access) throws MojoExecutionException, DockerAccessException {
         Boolean startCalled = (Boolean) getPluginContext().get(CONTEXT_KEY_START_CALLED);
 
+        QueryService queryService = serviceFactory.getQueryService(access, log);
+        RunService runService = serviceFactory.getRunService(access, log);
+
+        
         if (!keepRunning) {
             if (startCalled == null || !startCalled) {
                 // Called directly ....

--- a/src/main/java/org/jolokia/docker/maven/WatchMojo.java
+++ b/src/main/java/org/jolokia/docker/maven/WatchMojo.java
@@ -55,12 +55,6 @@ public class WatchMojo extends AbstractBuildSupporMojo {
     /** @parameter property = "docker.watchMode" default-value="both" **/
     private WatchMode watchMode;
 
-    /** @component **/
-    protected RunService runService;
-    
-    /** @component **/
-    protected MojoExecutionService mojoExecutionService;
-
     /**
      * @parameter property = "docker.watchInterval" default-value = "5000"
      */
@@ -78,23 +72,30 @@ public class WatchMojo extends AbstractBuildSupporMojo {
 
     // Scheduler
     private ScheduledExecutorService executor;
-
-    @Override
-    protected void initializeServices(DockerAccess access, QueryService queryService, Logger log) {
-        super.initializeServices(access, queryService, log);
-        runService.initialize(access, queryService, log);
-    }
-
+   
+    private QueryService queryService;
+    
+    private RunService runService;
+    
+    
     @Override
     protected synchronized void executeInternal(DockerAccess dockerAccess) throws DockerAccessException, MojoExecutionException {
         // Important to be be a single threaded scheduler since watch jobs must run serialized
         executor = Executors.newSingleThreadScheduledExecutor();
+        
+        queryService = serviceFactory.getQueryService(dockerAccess, log);
+        runService = serviceFactory.getRunService(dockerAccess, log);
+        
         MojoParameters mojoParameters = createMojoParameters();
+        
         try {
             for (StartOrderResolver.Resolvable resolvable : runService.getImagesConfigsInOrder(queryService, getImages())) {
                 final ImageConfiguration imageConfig = (ImageConfiguration) resolvable;
 
-                ImageWatcher watcher = new ImageWatcher(imageConfig, queryService.getImageId(imageConfig.getName()));
+                String imageId = queryService.getImageId(imageConfig.getName());
+                String containerId = runService.lookupContainer(imageConfig.getName());
+                
+                ImageWatcher watcher = new ImageWatcher(imageConfig, imageId, containerId);
 
                 ArrayList<String> tasks = new ArrayList<>();
 
@@ -122,8 +123,8 @@ public class WatchMojo extends AbstractBuildSupporMojo {
         }
     }
 
-    private void scheduleBuildWatchTask(DockerAccess dockerAccess, ImageWatcher watcher, MojoParameters mojoParameters, boolean doRestart)
-            throws MojoExecutionException {
+    private void scheduleBuildWatchTask(DockerAccess dockerAccess, ImageWatcher watcher, 
+            MojoParameters mojoParameters, boolean doRestart) throws MojoExecutionException {
         executor.scheduleAtFixedRate(
                 createBuildWatchTask(dockerAccess, watcher, mojoParameters, doRestart),
                 0, watcher.getInterval(), TimeUnit.MILLISECONDS);
@@ -151,7 +152,7 @@ public class WatchMojo extends AbstractBuildSupporMojo {
                         buildImage(docker, name, imageConfig);
                         watcher.setImageId(queryService.getImageId(name));
                         if (doRestart) {
-                            restartContainer(docker,watcher);
+                            restartContainer(watcher);
                         }
                         callPostGoal(watcher);
                     } catch (DockerAccessException | MojoExecutionException | MojoFailureException e) {
@@ -176,7 +177,7 @@ public class WatchMojo extends AbstractBuildSupporMojo {
                     String currentImageId = queryService.getImageId(imageName);
                     String oldValue = watcher.getAndSetImageId(currentImageId);
                     if (!currentImageId.equals(oldValue)) {
-                        restartContainer(docker, watcher);
+                        restartContainer(watcher);
                         callPostGoal(watcher);
                     }
                 } catch (DockerAccessException | MojoFailureException | MojoExecutionException e) {
@@ -196,7 +197,7 @@ public class WatchMojo extends AbstractBuildSupporMojo {
     }
 
 
-    private void restartContainer(DockerAccess docker, ImageWatcher watcher) throws DockerAccessException {
+    private void restartContainer(ImageWatcher watcher) throws DockerAccessException {
         // Stop old one
         ImageConfiguration imageConfig = watcher.getImageConfiguration();
         PortMapping mappedPorts = runService.getPortMapping(imageConfig.getRunConfiguration(), project.getProperties());
@@ -210,7 +211,7 @@ public class WatchMojo extends AbstractBuildSupporMojo {
     private void callPostGoal(ImageWatcher watcher) throws MojoFailureException, MojoExecutionException {
         String postGoal = watcher.getPostGoal();
         if (postGoal != null) {
-            mojoExecutionService.callPluginGoal(postGoal);
+            serviceFactory.getMojoExecutionService().callPluginGoal(postGoal);
         }
     }
 
@@ -226,11 +227,11 @@ public class WatchMojo extends AbstractBuildSupporMojo {
         private final ImageConfiguration imageConfig;
         private final String postGoal;
 
-        public ImageWatcher(ImageConfiguration imageConfig, String imageId) {
+        public ImageWatcher(ImageConfiguration imageConfig, String imageId, String containerIdRef) {
             this.imageConfig = imageConfig;
 
             this.imageIdRef = new AtomicReference<>(imageId);
-            this.containerIdRef = new AtomicReference<>(runService.lookupContainer(imageConfig.getName()));
+            this.containerIdRef = new AtomicReference<>(containerIdRef);
 
             this.interval = getWatchInterval(imageConfig);
             this.mode = getWatchMode(imageConfig);

--- a/src/main/java/org/jolokia/docker/maven/access/UrlBuilder.java
+++ b/src/main/java/org/jolokia/docker/maven/access/UrlBuilder.java
@@ -2,6 +2,8 @@ package org.jolokia.docker.maven.access;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import org.jolokia.docker.maven.util.ImageName;
 
@@ -56,14 +58,18 @@ public final class UrlBuilder {
         return url;
     }
 
-    public String inspectContainer(String containerId) {
-        return createUrl(String.format("/containers/%s/json", encode(containerId)));
+    public DockerUrl inspectContainer(String containerId) {
+        return createDockerUrl(String.format("/containers/%s/json", encode(containerId)));
     }
     
-    public String listContainers(int limit) {
-        return createUrl(String.format("/containers/json?limit=%s", limit));
+    public DockerUrl listContainers() {
+        return createDockerUrl(String.format("/containers/json"));
     }
 
+    public DockerUrl listImages() {
+        return createDockerUrl("/images/json");
+    }
+    
     public String listImages(ImageName name) {
         return createUrl(String.format("/images/json?filter=%s", name.getNameWithoutTag()));
     }
@@ -136,16 +142,20 @@ public final class UrlBuilder {
         return addQueryParam(url, "force", force);
     }
 
+    private DockerUrl createDockerUrl(String path) {
+        return new DockerUrl(createUrl(path));
+    }
+
     private String createUrl(String path) {
         return String.format("%s/%s%s", baseUrl, apiVersion, path);
     }
 
     @SuppressWarnings("deprecation")
-    private String encode(String param) {
+    private static String encode(String param) {
         try {
             return URLEncoder.encode(param, "UTF-8");
         }
-        catch (UnsupportedEncodingException e) {
+        catch (@SuppressWarnings("unused") UnsupportedEncodingException e) {
             // wont happen
             return URLEncoder.encode(param);
         }
@@ -158,4 +168,34 @@ public final class UrlBuilder {
         }
         return ret;
     }
+    
+    public static class DockerUrl {
+        private final String url;
+        private final Map<String, String> queryParams;
+        
+        DockerUrl(String url) {            
+            this.url = url;
+            this.queryParams = new LinkedHashMap<>();
+        }
+        
+        public void addQueryParam(String key, String value) {
+            queryParams.put(key, value);
+        }
+        
+        @Override
+        public String toString() {
+            StringBuilder builder = new StringBuilder(url);
+            builder.append("?");
+            
+            int count = queryParams.size();
+            for (Map.Entry<String, String> entry : queryParams.entrySet()) {
+                builder.append(entry.getKey()).append("=").append(encode(entry.getValue()));
+                if (--count > 0) {
+                    builder.append("&");
+                }
+            }
+            
+            return builder.toString();
+        }
+    }    
 }

--- a/src/main/java/org/jolokia/docker/maven/access/hc/DockerAccessWithHcClient.java
+++ b/src/main/java/org/jolokia/docker/maven/access/hc/DockerAccessWithHcClient.java
@@ -5,11 +5,13 @@ import java.net.URI;
 import java.util.*;
 
 import org.jolokia.docker.maven.access.*;
+import org.jolokia.docker.maven.access.UrlBuilder.DockerUrl;
 import org.jolokia.docker.maven.access.chunked.*;
 import org.jolokia.docker.maven.access.hc.http.*;
 import org.jolokia.docker.maven.access.hc.unix.UnixSocketClientBuilder;
 import org.jolokia.docker.maven.access.hc.ApacheHttpClientDelegate.Result;
 import org.jolokia.docker.maven.access.log.*;
+import org.jolokia.docker.maven.model.*;
 import org.jolokia.docker.maven.util.ImageName;
 import org.jolokia.docker.maven.util.Logger;
 import org.json.JSONArray;
@@ -61,32 +63,6 @@ public class DockerAccessWithHcClient implements DockerAccess {
     }
 
     @Override
-    public boolean hasImage(String image) throws DockerAccessException {
-        ImageName name = new ImageName(image);
-        try {
-            String response = get(urlBuilder.listImages(name), HTTP_OK).getMessage();
-            JSONArray array = new JSONArray(response);
-
-            return containsImage(name, array);
-        } catch (HttpRequestException e) {
-            log.error(e.getMessage());
-            throw new DockerAccessException("Unable to check for image [%s]", image);
-        }
-    }
-
-    @Override
-    public String getImageId(String image) throws DockerAccessException {
-        try {
-            String response = get(urlBuilder.inspectImage(image), HTTP_OK).getMessage();
-            JSONObject json = new JSONObject(response);
-            return json.getString("Id");
-        } catch (HttpRequestException e) {
-            log.error(e.getMessage());
-            throw new DockerAccessException("Unable to find Id for image [%s]", image);
-        }
-    }
-
-    @Override
     public String createContainer(ContainerCreateConfig containerConfig, String containerName) throws DockerAccessException {
         String createJson = containerConfig.toJson();
         log.debug("Container create config: " + createJson);
@@ -102,24 +78,6 @@ public class DockerAccessWithHcClient implements DockerAccess {
         catch (HttpRequestException e) {
             log.error(e.getMessage());
             throw new DockerAccessException("Unable to create container for [%s]", containerConfig.getImageName());
-        }
-    }
-
-    @Override
-    public String getContainerName(String containerId) throws DockerAccessException {
-        try {
-            String response = get(urlBuilder.inspectContainer(containerId), HTTP_OK).getMessage();
-            JSONObject json = new JSONObject(response);
-
-            String name =  json.getString("Name");
-            if (name.startsWith("/")) {
-                name = name.substring(1);
-            }
-
-            return name;
-        } catch (HttpRequestException e) {
-            log.error(e.getMessage());
-            throw new DockerAccessException("Unable to retrieve container name for [%s]", containerId);
         }
     }
 
@@ -170,31 +128,6 @@ public class DockerAccessWithHcClient implements DockerAccess {
     }
 
     @Override
-    public List<String> getContainersForImage(String image) throws DockerAccessException {
-        return getContainerIds(image, false);
-    }
-
-    @Override
-    public String getNewestImageForContainer(String image) throws DockerAccessException {
-        List<String> newestContainer = getContainerIds(image, true);
-        assert newestContainer.size() == 0 || newestContainer.size() == 1;
-        return newestContainer.size() == 0 ? null : newestContainer.get(0);
-    }
-
-    @Override
-    public boolean isContainerRunning(String containerId) throws DockerAccessException {
-        try {
-            String response = get(urlBuilder.inspectContainer(containerId), HTTP_OK).getMessage();
-            JSONObject json = new JSONObject(response);
-
-            return json.getJSONObject("State").getBoolean("Running");
-        } catch (HttpRequestException e) {
-            log.error(e.getMessage());
-            throw new DockerAccessException("Unable to determine state of container [%s]", containerId);
-        }
-    }
-
-    @Override
     public void getLogSync(String containerId, LogCallback callback) {
         LogRequestor extractor = new LogRequestor(delegate.getHttpClient(), urlBuilder, containerId, callback);
         extractor.fetchLogs();
@@ -206,6 +139,58 @@ public class DockerAccessWithHcClient implements DockerAccess {
         extractor.start();
         return extractor;
     }
+    
+    @Override
+    public ContainerDetails inspectContainer(String containerId) throws DockerAccessException {
+        try {
+            String response = get(urlBuilder.inspectContainer(containerId), HTTP_OK).getMessage();
+            return new ContainerDetails(response);
+        } catch (HttpRequestException e) {
+            log.error(e.getMessage());
+            throw new DockerAccessException("Unable to retrieve container name for [%s]", containerId);
+        }
+    } 
+    
+    @Override
+    public List<Container> listContainers(ListArg... args) throws DockerAccessException {
+        DockerUrl url = buildDockerUrl(urlBuilder.listContainers(), args);
+
+        try {
+            String response = get(url, HTTP_OK).getMessage();
+            JSONArray array = new JSONArray(response);
+            List<Container> containers = new ArrayList<>(array.length());
+            
+            for (int i = 0; i < array.length(); i++) {
+                containers.add(new Container(array.getJSONObject(i)));
+            }
+            
+            return containers;
+        }
+        catch (HttpRequestException e) {
+            throw new DockerAccessException(e.getMessage());
+        }
+    }
+    
+    @Override
+    public List<Image> listImages(ListArg... args) throws DockerAccessException {
+        DockerUrl url = buildDockerUrl(urlBuilder.listImages(), args);
+
+        try {
+            String response = get(url, HTTP_OK).getMessage();
+            JSONArray array = new JSONArray(response);
+            List<Image> images = new ArrayList<>(array.length());
+        
+            for (int i = 0; i < array.length(); i++) {
+                images.add(new Image(array.getJSONObject(i)));
+            }
+            
+            return images;
+        }
+        catch (HttpRequestException e) {
+            log.error(e.getMessage());
+            throw new DockerAccessException("Unable to list images");
+        }
+    }    
 
     @Override
     public void removeContainer(String containerId, boolean removeVolumes) throws DockerAccessException {
@@ -306,66 +291,6 @@ public class DockerAccessWithHcClient implements DockerAccess {
         return Collections.singletonMap("X-Registry-Auth", authConfig.toHeaderValue());
     }
 
-    private boolean containsImage(ImageName name, JSONArray array) {
-        if (array.length() > 0) {
-            for (int i = 0; i < array.length(); i++) {
-                JSONObject imageObject = array.getJSONObject(i);
-                JSONArray repoTags = imageObject.getJSONArray("RepoTags");
-                for (int j = 0; j < repoTags.length(); j++) {
-                    if (name.getFullName().equals(repoTags.getString(j))) {
-                        return true;
-                    }
-                }
-            }
-        }
-        return false;
-    }
-
-    private List<String> extractMatchingContainers(boolean onlyLatest, String imageFullName, JSONArray configs) {
-        long newest = 0;
-        List<String> ret = new ArrayList<>();
-        for (int i = 0; i < configs.length(); i ++) {
-            JSONObject config = configs.getJSONObject(i);
-
-            String id = config.getString("Id");
-            String containerImage = config.getString("Image");
-
-            if (!imageFullName.equals(containerImage)) {
-                continue;
-            }
-
-            if (!onlyLatest) {
-                ret.add(id);
-                continue;
-            }
-
-            int timestamp = config.getInt("Created");
-            if (timestamp > newest) {
-                newest = timestamp;
-                if (ret.size() == 0) {
-                    ret.add(id);
-                } else {
-                    ret.set(0, id);
-                }
-            }
-        }
-        return ret;
-    }
-
-    private List<String> getContainerIds(String image, boolean onlyLatest) throws DockerAccessException {
-        ImageName imageName = new ImageName(image);
-        String imageFullName = imageName.getFullName();
-
-        try {
-            String response = get(urlBuilder.listContainers(100), HTTP_OK).getMessage();
-            JSONArray array = new JSONArray(response);
-
-            return extractMatchingContainers(onlyLatest, imageFullName, array);
-        } catch (HttpRequestException e) {
-            throw new DockerAccessException(e.getMessage());
-        }
-    }
-
     private String tagTemporaryImage(ImageName name, String registry) throws DockerAccessException {
         String targetImage = name.getFullName(registry);
         if (!name.hasRegistry() && registry != null && !isDefaultRegistry(registry) && !hasImage(targetImage)) {
@@ -381,7 +306,6 @@ public class DockerAccessWithHcClient implements DockerAccess {
                "registry.hub.docker.com".equalsIgnoreCase(registry);
     }
 
-
     // ===========================================================================================================
 
     private Result delete(String url, int statusCode, int... additional) throws HttpRequestException, DockerAccessException {
@@ -392,9 +316,9 @@ public class DockerAccessWithHcClient implements DockerAccess {
         }
     }
 
-    private Result get(String url, int statusCode, int... additional) throws HttpRequestException, DockerAccessException {
+    private Result get(DockerUrl url, int statusCode, int... additional) throws HttpRequestException, DockerAccessException {
         try {
-            return delegate.get(url, statusCode, additional);
+            return delegate.get(url.toString(), statusCode, additional);
         } catch (IOException e) {
             throw new DockerAccessException(e, "Communication error with the docker daemon");
         }
@@ -419,6 +343,14 @@ public class DockerAccessWithHcClient implements DockerAccess {
     // ===========================================================================================================
     // Preparation for performing requests
 
+    private DockerUrl buildDockerUrl(DockerUrl url, ListArg... args) {
+        for (ListArg arg : args) {
+            url.addQueryParam(arg.getKey(), arg.getValue());
+        }
+
+        return url;
+    }
+    
     private Map<String, Integer> extractPorts(JSONObject info) {
         JSONObject networkSettings = info.getJSONObject("NetworkSettings");
         if (networkSettings != null) {
@@ -503,7 +435,15 @@ public class DockerAccessWithHcClient implements DockerAccess {
         }
     }
 
+    private boolean isDockerIndexIo(String registry) {
+        return (registry != null && registry.equals("index.docker.io"));
+    }
+
     private boolean isSSL(String url) {
         return url != null && url.toLowerCase().startsWith("https");
+    } 
+    
+    private boolean hasImage(String image) throws DockerAccessException {
+        return !listImages(ListArg.filter(image)).isEmpty();
     }
 }

--- a/src/main/java/org/jolokia/docker/maven/model/Container.java
+++ b/src/main/java/org/jolokia/docker/maven/model/Container.java
@@ -1,0 +1,121 @@
+package org.jolokia.docker.maven.model;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+public class Container {
+
+    private final JSONObject json;
+
+    public Container(JSONObject json) {
+        this.json = json;
+    }
+
+    public Container(String json) {
+        this(new JSONObject(json));
+    }
+
+    public String getCommand() {
+        return json.getString("Command");
+    }
+
+    public long getCreated() {
+        return json.getLong("Created");
+    }
+
+    public String getId() {
+        return json.getString("Id");
+    }
+
+    public String getImage() {
+        return json.getString("Image");
+    }
+
+    public Map<String, String> getLabels() {
+        Map<String, String> map = new HashMap<>();
+
+        JSONObject labels = json.getJSONObject("Labels");
+        JSONArray keys = labels.names();
+
+        for (int i = 0; i < keys.length(); i++) {
+            String key = keys.getString(i);
+            map.put(key, labels.getString(key));
+        }
+
+        return map;
+    }
+
+    public String getName() {
+        for (String name : getNames()) {
+            if (name.startsWith("/")) {
+                name = name.substring(1);
+            }
+
+            if (name.indexOf("/") == -1) {
+                return name;
+            }
+        }
+
+        // this should never happen
+        throw new IllegalStateException("unable to determine container name");
+    }
+
+    public Collection<String> getNames() {
+        JSONArray array = json.getJSONArray("Names");
+        ArrayList<String> list = new ArrayList<>(array.length());
+
+        for (int i = 0; i < array.length(); i++) {
+            list.add(array.getString(i));
+        }
+
+        return list;
+    }
+
+    public Collection<Port> getPorts() {
+        JSONArray ports = json.getJSONArray("Ports");
+        ArrayList<Port> list = new ArrayList<>(ports.length());
+
+        for (int i = 0; i < ports.length(); i++) {
+            list.add(new Port(ports.getJSONObject(i)));
+        }
+
+        return list;
+    }
+
+    public String getStatus() {
+        return json.getString("Status");
+    }
+
+    public boolean isRunning() {
+        return getStatus().contains("Up");
+    }
+
+    public class Port {
+        private final JSONObject json;
+
+        Port(JSONObject json) {
+            this.json = json;
+        }
+
+        public String getIp() {
+            return json.getString("IP");
+        }
+
+        public int getPrivatePort() {
+            return json.getInt("PrivatePort");
+        }
+
+        public int getPublicPort() {
+            return json.getInt("PublicPort");
+        }
+
+        public String getType() {
+            return json.getString("Type");
+        }
+    }
+}

--- a/src/main/java/org/jolokia/docker/maven/model/ContainerDetails.java
+++ b/src/main/java/org/jolokia/docker/maven/model/ContainerDetails.java
@@ -1,0 +1,38 @@
+package org.jolokia.docker.maven.model;
+
+import org.json.JSONObject;
+
+public class ContainerDetails {
+
+    private final JSONObject json;
+
+    public ContainerDetails(String json) {
+        this.json = new JSONObject(json);
+    }
+
+    public String getName() {
+        String name = json.getString("Name");
+
+        if (name.startsWith("/")) {
+            name = name.substring(1);
+        }
+        
+        return name;
+    }
+    
+    public State getState() {
+        return new State(json.getJSONObject("State"));
+    }
+
+    public class State {
+        private final JSONObject json;
+
+        State(JSONObject json) {
+            this.json = json;
+        }
+
+        public boolean isRunning() {
+            return json.getBoolean("Running");
+        }
+    }
+}

--- a/src/main/java/org/jolokia/docker/maven/model/Image.java
+++ b/src/main/java/org/jolokia/docker/maven/model/Image.java
@@ -1,0 +1,35 @@
+package org.jolokia.docker.maven.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+public class Image {
+
+    private final JSONObject json;
+   
+    public Image(JSONObject json) {
+        this.json = json;
+    }
+    
+    public Image(String json) {
+       this(new JSONObject(json));
+    }
+    
+    public String getId() {
+        return json.getString("Id");
+    }
+
+    public List<String> getRepoTags() {
+        JSONArray array = json.getJSONArray("RepoTags");
+        List<String> tags = new ArrayList<>(array.length());
+        
+        for (int i = 0; i < array.length(); i++) {
+            tags.add(array.getString(i));
+        }
+
+        return tags;
+    }    
+}

--- a/src/main/java/org/jolokia/docker/maven/service/DependencyTracker.java
+++ b/src/main/java/org/jolokia/docker/maven/service/DependencyTracker.java
@@ -1,0 +1,61 @@
+package org.jolokia.docker.maven.service;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.jolokia.docker.maven.config.ImageConfiguration;
+
+public class DependencyTracker {
+
+    // Map holding associations between started containers and their images via name and aliases
+    // Key: Image, Value: Container
+    private Map<String, String> containerImageNameMap = new HashMap<>();
+
+    // Key: Alias, Value: Image
+    private Map<String, String> imageAliasMap = new HashMap<>();
+
+    // Action to be used when doing a shutdown
+    private final Map<String,ShutdownAction> shutdownActionMap = new LinkedHashMap<>();
+    
+    public void registerShutdownAction(String id, ImageConfiguration imageConfig) {
+        shutdownActionMap.put(id, new ShutdownAction(imageConfig, id));
+        updateImageToContainerMapping(imageConfig, id);
+    }
+    
+    public ShutdownAction getShutdownAction(String containerId) {
+        return shutdownActionMap.get(containerId);
+    }
+    
+    public ShutdownAction removeShutdownAction(String containerId) {
+        return shutdownActionMap.remove(containerId);
+    }
+    
+    public String lookupContainer(String lookup) {
+        String image = imageAliasMap.containsKey(lookup) ? imageAliasMap.get(lookup) : lookup;
+        return containerImageNameMap.get(image);
+    }
+
+    public void resetShutdownActions() {
+        shutdownActionMap.clear();
+    }
+    
+    public Collection<ShutdownAction> getAllShutdownActions() {
+        List<ShutdownAction> actions = new ArrayList<>(shutdownActionMap.values());
+        Collections.reverse(actions);
+
+        return actions;
+    }
+    
+    private void updateImageToContainerMapping(ImageConfiguration imageConfig, String id) {
+        // Register name -> containerId and alias -> name
+        containerImageNameMap.put(imageConfig.getName(), id);
+        if (imageConfig.getAlias() != null) {
+            imageAliasMap.put(imageConfig.getAlias(), imageConfig.getName());
+        }
+    }
+}

--- a/src/main/java/org/jolokia/docker/maven/service/MojoExecutionService.java
+++ b/src/main/java/org/jolokia/docker/maven/service/MojoExecutionService.java
@@ -44,15 +44,17 @@ import org.eclipse.aether.RepositorySystemSession;
  */
 public class MojoExecutionService {
 
-    /** @component */
-    protected MavenProject project;
+    private final MavenProject project;
 
-    /** @component */
-    protected MavenSession session;
+    private final MavenSession session;
 
-    /** @component **/
-    protected BuildPluginManager pluginManager;
+    private final BuildPluginManager pluginManager;
 
+    MojoExecutionService( MavenProject project, MavenSession session, BuildPluginManager pluginManager) {
+        this.project = project;
+        this.session = session;
+        this.pluginManager = pluginManager;
+    }
 
     // Call another goal after restart has finished
     public void callPluginGoal(String fullGoal) throws MojoFailureException, MojoExecutionException {

--- a/src/main/java/org/jolokia/docker/maven/service/QueryService.java
+++ b/src/main/java/org/jolokia/docker/maven/service/QueryService.java
@@ -22,6 +22,11 @@ public class QueryService {
     
     private Logger log;
 
+    public QueryService(DockerAccess docker, Logger log) {
+        this.docker = docker;
+        this.log = log;
+    }
+    
     public ContainerDetails getContainer(String containerId) throws DockerAccessException {
         return docker.inspectContainer(containerId);
     }

--- a/src/main/java/org/jolokia/docker/maven/service/QueryService.java
+++ b/src/main/java/org/jolokia/docker/maven/service/QueryService.java
@@ -1,0 +1,196 @@
+package org.jolokia.docker.maven.service;
+
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.jolokia.docker.maven.access.DockerAccess;
+import org.jolokia.docker.maven.access.DockerAccess.ListArg;
+import org.jolokia.docker.maven.access.DockerAccessException;
+import org.jolokia.docker.maven.model.Container;
+import org.jolokia.docker.maven.model.ContainerDetails;
+import org.jolokia.docker.maven.model.Image;
+import org.jolokia.docker.maven.util.AutoPullMode;
+import org.jolokia.docker.maven.util.ImageName;
+import org.jolokia.docker.maven.util.Logger;
+
+public class QueryService {
+
+    private static final ListArg LIMIT = ListArg.limit(100);
+
+    private DockerAccess docker;
+    
+    private Logger log;
+
+    public ContainerDetails getContainer(String containerId) throws DockerAccessException {
+        return docker.inspectContainer(containerId);
+    }
+
+    public Container getContainerByName(final String name) throws DockerAccessException {
+        List<Container> containers = filter(docker.listContainers(LIMIT), new Filter<Container>() {
+            @Override
+            public boolean matches(Container toFilter) {
+                return !name.equals(toFilter.getName());
+            }
+        });
+        
+        return (containers.isEmpty()) ? null : containers.get(0);
+    }
+
+    public String getContainerName(String containerId) throws DockerAccessException {
+        return getContainer(containerId).getName();
+    }
+
+    /**
+     * Get all containers which are build from an image. Only the last 100 containers are considered
+     *
+     * @param image for which its container are looked up
+     * @return list of <code>Container</code> objects
+     * @throws DockerAccessException if the request fails
+     */
+    public List<Container> getContainersForImage(final String image) throws DockerAccessException {
+        return filter(docker.listContainers(LIMIT), new Filter<Container>() {
+            @Override
+            public boolean matches(Container toFilter) {
+                return !image.equals(toFilter.getImage());
+            }
+        });
+    }
+
+    public Image getImage(String image) throws DockerAccessException {
+        String name = new ImageName(image).getNameWithoutTag();
+        return docker.listImages(ListArg.filter(name)).get(0);
+    }
+    
+    /**
+     * Finds the id of an image.
+     * 
+     * @param image name of the image.
+     * @return the id of the image
+     * @throws DockerAccessException if the request fails
+     */
+    public String getImageId(String image) throws DockerAccessException {
+        return getImage(image).getId();
+    }
+    
+    /**
+     * Get the id of the latest container started for an image
+     *
+     * @param image for which its container are looked up
+     * @return container or <code>null</code> if no container has been started for this image.
+     * @throws DockerAccessException if the request fails
+     */
+    public Container getLatestContainerForImage(String image) throws DockerAccessException {
+        long newest = 0;
+        Container result = null;
+
+        for (Container container : getContainersForImage(image)) {
+            long timestamp = container.getCreated();
+
+            if (timestamp < newest) {
+                continue;
+            }
+
+            newest = timestamp;
+            result = container;
+        }
+
+        return result;
+    }
+
+    public boolean hasContainerNamed(String name) throws DockerAccessException {
+        return (getContainerByName(name) != null);
+    }
+    
+    /**
+     * Check whether the given Image is locally available.
+     *
+     * @param name name of image to check, the image can contain a tag, otherwise 'latest' will be appended
+     * @return true if the image is locally available or false if it must be pulled.
+     * @throws DockerAccessException if the request fails
+     */
+    public boolean hasImage(String name) throws DockerAccessException {
+        ImageName imageName = new ImageName(name);
+
+        String fullName = imageName.getFullName();
+        String nameWithoutTag = imageName.getNameWithoutTag();
+
+        for (Image image : docker.listImages(ListArg.filter(nameWithoutTag))) {
+            if (image.getRepoTags().contains(fullName)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public boolean hasRunningContainerNamed(String name) throws DockerAccessException{
+        Container container = getContainerByName(name);
+        return (container == null) ? false  : container.isRunning();
+    }
+    
+    public boolean imageRequiresAutoPull(String mode, String name, String registry, boolean always)
+        throws DockerAccessException, MojoExecutionException {
+
+        // The logic here is like this (see also #96):
+        // If the image is not available and mode is either ON or ALWAYS --> pull
+        // If mode == ALWAYS and no build config is available (so its a pulled-image anyway) --> pull
+        // otherwise: don't pull
+        AutoPullMode autoPull = AutoPullMode.fromString(mode);
+        boolean pullImage;
+        if (pullIfNotPresent(autoPull, name) || alwaysAutoPull(autoPull, always)) {
+            pullImage = true;
+        } else {
+            if (!hasImage(name)) {
+                throw new MojoExecutionException(
+                        String.format("No image '%s' found, Please enable 'autoPull' or pull image '%s'yourself (docker pull %s)",
+                                name, name, name));
+            }
+
+            pullImage = false;
+        }
+
+        return pullImage;
+    }
+
+    public void initialize(DockerAccess docker, Logger log) {
+        this.docker = docker;
+        this.log = log;
+    }
+
+    /**
+     * Determine if the container is running
+     * 
+     * @param containerId id of container to query
+     * @return true if the container is running, false otherwise
+     * @throws DockerAccessException if the request fails
+     */
+    public boolean isContainerRunning(String containerId) throws DockerAccessException {
+        return docker.inspectContainer(containerId).getState().isRunning();
+    }
+
+    private boolean alwaysAutoPull(AutoPullMode autoPull, boolean always) {
+        return (always && autoPull == AutoPullMode.ALWAYS);
+    }
+
+    private <T> List<T> filter(List<T> list, Filter<T> filter) {
+        Iterator<T> iterator = list.iterator();
+
+        while (iterator.hasNext()) {
+            if (filter.matches(iterator.next())) {
+                iterator.remove();
+            }
+        }
+
+        return list;
+    }
+    
+
+    private boolean pullIfNotPresent(AutoPullMode autoPull, String name) throws DockerAccessException {
+        return (autoPull.doPullIfNotPresent() & !hasImage(name));
+    }
+
+    private interface Filter<T> {
+        boolean matches(T toFilter);
+    }
+}

--- a/src/main/java/org/jolokia/docker/maven/service/ServiceFactory.java
+++ b/src/main/java/org/jolokia/docker/maven/service/ServiceFactory.java
@@ -1,0 +1,51 @@
+package org.jolokia.docker.maven.service;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.BuildPluginManager;
+import org.apache.maven.project.MavenProject;
+import org.jolokia.docker.maven.access.DockerAccess;
+import org.jolokia.docker.maven.util.Logger;
+
+public class ServiceFactory {
+
+    private static final DependencyTracker tracker = new DependencyTracker();
+    
+    /** @component **/
+    protected BuildPluginManager pluginManager;
+    
+    /** @component */
+    protected MavenProject project;
+    
+    /** @component */
+    protected MavenSession session;
+
+    private MojoExecutionService mojoExecutionService;
+
+    private QueryService queryService;
+
+    private RunService runService;
+
+    public synchronized MojoExecutionService getMojoExecutionService() {
+        if (mojoExecutionService == null) {
+            mojoExecutionService = new MojoExecutionService(project, session, pluginManager);
+        }
+        
+        return mojoExecutionService;
+    }
+
+    public synchronized QueryService getQueryService(DockerAccess docker, Logger log) {
+        if (queryService == null) {
+            queryService = new QueryService(docker, log);
+        }
+        
+        return queryService;
+    }
+
+    public synchronized RunService getRunService(DockerAccess docker, Logger log) {
+        if (runService == null) {
+            runService = new RunService(docker, getQueryService(docker, log), tracker, log);
+        }
+        
+        return runService;
+    }
+}

--- a/src/main/java/org/jolokia/docker/maven/util/StartOrderResolver.java
+++ b/src/main/java/org/jolokia/docker/maven/util/StartOrderResolver.java
@@ -118,7 +118,8 @@ public class StartOrderResolver {
         }
 
         for (String dependency : dependencies) {
-            if (processedImages.contains(dependency) || queryService.hasRunningContainerNamed(dependency)) {
+            // make sure the container exists, it's state will be verified elsewhere
+            if (processedImages.contains(dependency) || queryService.hasContainerNamed(dependency)) {
                 continue;
             }
 

--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -27,6 +27,12 @@
     </component>
 
     <component>
+      <role>org.jolokia.docker.maven.service.QueryService</role>
+      <implementation>org.jolokia.docker.maven.service.QueryService</implementation>
+      <instantiation-strategy>singleton</instantiation-strategy>
+    </component>
+
+    <component>
       <role>org.jolokia.docker.maven.service.MojoExecutionService</role>
       <implementation>org.jolokia.docker.maven.service.MojoExecutionService</implementation>
       <instantiation-strategy>singleton</instantiation-strategy>

--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -21,14 +21,8 @@
     </component>
 
     <component>
-      <role>org.jolokia.docker.maven.service.RunService</role>
-      <implementation>org.jolokia.docker.maven.service.RunService</implementation>
-      <instantiation-strategy>singleton</instantiation-strategy>
-    </component>
-
-    <component>
-      <role>org.jolokia.docker.maven.service.QueryService</role>
-      <implementation>org.jolokia.docker.maven.service.QueryService</implementation>
+      <role>org.jolokia.docker.maven.service.ServiceFactory</role>
+      <implementation>org.jolokia.docker.maven.service.ServiceFactory</implementation>
       <instantiation-strategy>singleton</instantiation-strategy>
     </component>
 

--- a/src/test/java/org/jolokia/docker/maven/service/RunServiceTest.java
+++ b/src/test/java/org/jolokia/docker/maven/service/RunServiceTest.java
@@ -102,26 +102,26 @@ public class RunServiceTest {
                 result = "otherContainer";
         }};
         
-        RunService runService = new RunService();
-        runService.initialize(docker, queryService, log);
+        DependencyTracker tracker = new DependencyTracker();
+        RunService runService = new RunService(docker, queryService, tracker, log);
         
         PortMapping portMapping = runService.getPortMapping(runConfig, new Properties());
 
         // Better than poking into the private vars would be to use createAndStart() with the mock to build up the map.
         ImageConfiguration imageConfig2 = new ImageConfiguration.Builder().alias("db").name("redis3").build();
-        putToPrivateMap(runService, "containerImageNameMap", imageConfig2.getName(), "redisContainer");
+        putToPrivateMap(tracker, "containerImageNameMap", imageConfig2.getName(), "redisContainer");
         if (imageConfig2.getAlias() != null) {
-            putToPrivateMap(runService,"imageAliasMap",imageConfig2.getAlias(), imageConfig2.getName());
+            putToPrivateMap(tracker,"imageAliasMap",imageConfig2.getAlias(), imageConfig2.getName());
         }
         ImageConfiguration imageConfig1 = new ImageConfiguration.Builder().alias("parent").name("parentName").build();
-        putToPrivateMap(runService,"containerImageNameMap",imageConfig1.getName(), "parentContainer");
+        putToPrivateMap(tracker,"containerImageNameMap",imageConfig1.getName(), "parentContainer");
         if (imageConfig1.getAlias() != null) {
-            putToPrivateMap(runService,"imageAliasMap",imageConfig1.getAlias(), imageConfig1.getName());
+            putToPrivateMap(tracker,"imageAliasMap",imageConfig1.getAlias(), imageConfig1.getName());
         }
         ImageConfiguration imageConfig = new ImageConfiguration.Builder().alias("other:ro").name("otherName").build();
-        putToPrivateMap(runService,"containerImageNameMap",imageConfig.getName(), "otherContainer");
+        putToPrivateMap(tracker,"containerImageNameMap",imageConfig.getName(), "otherContainer");
         if (imageConfig.getAlias() != null) {
-            putToPrivateMap(runService,"imageAliasMap", imageConfig.getAlias(), imageConfig.getName());
+            putToPrivateMap(tracker,"imageAliasMap", imageConfig.getAlias(), imageConfig.getName());
         }
         ContainerCreateConfig containerConfig = runService.createContainerConfig("base", runConfig, portMapping, new Properties());
 
@@ -133,10 +133,10 @@ public class RunServiceTest {
         JSONAssert.assertEquals(expectedHostConfig, startConfig.toJson(), true);
     }
 
-    private void putToPrivateMap(RunService runService, String varName, String key, String value) throws NoSuchFieldException, IllegalAccessException {
-        Field field = runService.getClass().getDeclaredField(varName);
+    private void putToPrivateMap(DependencyTracker tracker, String varName, String key, String value) throws NoSuchFieldException, IllegalAccessException {
+        Field field = tracker.getClass().getDeclaredField(varName);
         field.setAccessible(true);
-        Map<String,String> map = (Map<String, String>) field.get(runService);
+        Map<String,String> map = (Map<String, String>) field.get(tracker);
         map.put(key,value);
     }
 

--- a/src/test/java/org/jolokia/docker/maven/util/StartOrderResolverTest.java
+++ b/src/test/java/org/jolokia/docker/maven/util/StartOrderResolverTest.java
@@ -28,7 +28,7 @@ public class StartOrderResolverTest {
     @SuppressWarnings("unused")
     public void setup() throws Exception {
         new Expectations() {{
-            queryService.hasRunningContainerNamed((String) withNotNull());
+            queryService.hasContainerNamed((String) withNotNull());
             result = false;
             minTimes = 1;
         }};

--- a/src/test/java/org/jolokia/docker/maven/util/StartOrderResolverTest.java
+++ b/src/test/java/org/jolokia/docker/maven/util/StartOrderResolverTest.java
@@ -1,12 +1,19 @@
 package org.jolokia.docker.maven.util;
 
-import java.util.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.fail;
 
-import org.apache.maven.plugin.MojoExecutionException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.jolokia.docker.maven.service.QueryService;
+import org.jolokia.docker.maven.util.StartOrderResolver.Resolvable;
+import org.junit.Before;
 import org.junit.Test;
 
-import static org.jolokia.docker.maven.util.StartOrderResolver.Resolvable;
-import static org.junit.Assert.*;
+import mockit.Expectations;
+import mockit.Mocked;
 
 /**
  * @author roland
@@ -14,8 +21,21 @@ import static org.junit.Assert.*;
  */
 public class StartOrderResolverTest {
 
+    @Mocked
+    private QueryService queryService;
+    
+    @Before
+    @SuppressWarnings("unused")
+    public void setup() throws Exception {
+        new Expectations() {{
+            queryService.hasRunningContainerNamed((String) withNotNull());
+            result = false;
+            minTimes = 1;
+        }};
+    }
+    
     @Test
-    public void simple() throws MojoExecutionException {
+    public void simple() {
         checkData(new Object[][]{
                 { new T[]{new T("1")}, new T[]{new T("1")}},
                 { new T[]{new T("1", "2"), new T("2")}, new T[]{new T("2"), new T("1", "2")} },
@@ -24,18 +44,18 @@ public class StartOrderResolverTest {
     }
 
     @Test(expected = IllegalStateException.class)
-    public void circularDep() throws MojoExecutionException {
+    public void circularDep() {
         checkData(new Object[][] {
                 {new T[]{new T("1", "2"), new T("2", "1")}, new T[]{new T("1", "2"), new T("2", "1")}}
         });
         fail();
     }
 
-    private void checkData(Object[][] data) throws MojoExecutionException {
+    private void checkData(Object[][] data) {
         for (Object[] aData : data) {
             Resolvable[] input = (Resolvable[]) aData[0];
             Resolvable[] expected = (Resolvable[]) aData[1];
-            List<Resolvable> result = StartOrderResolver.resolve(Arrays.asList(input));
+            List<Resolvable> result = StartOrderResolver.resolve(queryService, Arrays.asList(input));
             assertArrayEquals(expected, new ArrayList(result).toArray());
         }
     }


### PR DESCRIPTION
resolves #195 and #73 

- pulled fine grained query methods out of DockerAccess into QueryService
- added coarse grained list/inspect methods to DockerAccess
- introduced model objects
- refactored RunService to accept DocerAccess instance via 'initialize' method
- allow linking/mounting from external containers

Signed-off-by: Jae Gangemi <jgangemi@gmail.com>