### PR TITLE
resolves issue 207

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target/
 .classpath
 .project
 .settings
+.*.md.html

--- a/src/main/java/org/jolokia/docker/maven/BuildMojo.java
+++ b/src/main/java/org/jolokia/docker/maven/BuildMojo.java
@@ -31,16 +31,25 @@ public class BuildMojo extends AbstractBuildSupporMojo {
         for (ImageConfiguration imageConfig : getImages()) {
             BuildImageConfiguration buildConfig = imageConfig.getBuildConfiguration();
             if (buildConfig != null) {
-                buildConfig.validate();
-                String imageName = imageConfig.getName();
-                buildImage(dockerAccess, imageName, imageConfig);
-                if (!skipTags) {
-                    tagImage(imageName, imageConfig, dockerAccess);
+                if (imageConfig.getBuildRunMode().isBuild()) {
+                    buildImage(dockerAccess, imageConfig, buildConfig);
+                } else {
+                    log.info(imageConfig.getDescription() + ": Skipped, 'build' mode not enabled");
                 }
             }
         }
     }
 
+    private void buildImage(DockerAccess dockerAccess, ImageConfiguration imageConfig, BuildImageConfiguration buildConfig)
+        throws MojoExecutionException, DockerAccessException {
+        buildConfig.validate();
+        String imageName = imageConfig.getName();
+        buildImage(dockerAccess, imageName, imageConfig);
+        if (!skipTags) {
+            tagImage(imageName, imageConfig, dockerAccess);
+        }
+    }
+    
     private void tagImage(String imageName, ImageConfiguration imageConfig, DockerAccess dockerAccess)
             throws DockerAccessException, MojoExecutionException {
 

--- a/src/main/java/org/jolokia/docker/maven/config/BuildRunMode.java
+++ b/src/main/java/org/jolokia/docker/maven/config/BuildRunMode.java
@@ -1,0 +1,40 @@
+package org.jolokia.docker.maven.config;
+
+public enum BuildRunMode {
+
+    /**
+     * build and run the container
+     */
+    both(true, true),
+
+    /**
+     * build the container only
+     */
+    build(true, false),
+
+    /**
+     * run the container only
+     */
+    run(false, true),
+
+    /**
+     * ignore the container entirely
+     */
+    skip(false, false);
+    
+    private final boolean isBuild;
+    private final boolean isRun;
+
+    BuildRunMode(boolean build, boolean run) {
+        this.isBuild = build;
+        this.isRun = run;
+    }
+
+    public boolean isBuild() {
+        return isBuild;
+    }
+
+    public boolean isRun() {
+        return isRun;
+    }
+}

--- a/src/main/java/org/jolokia/docker/maven/config/ImageConfiguration.java
+++ b/src/main/java/org/jolokia/docker/maven/config/ImageConfiguration.java
@@ -47,21 +47,14 @@ public class ImageConfiguration implements StartOrderResolver.Resolvable {
      */
     private String registry;
 
+    /**
+     * @parameter default-value="both"
+     */
+    private BuildRunMode mode;
+    
     // Used for injection
     public ImageConfiguration() {}
-
-    // For builder
-    private ImageConfiguration(String name, String alias,
-                               RunImageConfiguration run, BuildImageConfiguration build,WatchImageConfiguration watch,
-                               Map<String, String> external) {
-        this.name = name;
-        this.alias = alias;
-        this.run = run;
-        this.build = build;
-        this.watch = watch;
-        this.external = external;
-    }
-
+   
     @Override
     public String getName() {
         return name;
@@ -124,9 +117,12 @@ public class ImageConfiguration implements StartOrderResolver.Resolvable {
         return getRunConfiguration() == null;
     }
 
+    public BuildRunMode getBuildRunMode() {
+        return (mode == null) ? BuildRunMode.both : mode;
+    }
+    
     public String getDescription() {
-        return "[" + name + "]" +
-               (alias != null ? " \"" + alias + "\"" : "");
+        return String.format("[%s] %s", name, (alias != null ? "\"" + alias + "\"" : ""));
     }
 
     public String getRegistry() {
@@ -135,55 +131,51 @@ public class ImageConfiguration implements StartOrderResolver.Resolvable {
 
     @Override
     public String toString() {
-        return "ImageConfiguration{" +
-               "name='" + name + '\'' +
-               ", alias='" + alias + '\'' +
-               '}';
+        return String.format("ImageConfiguration {name='%s', alias='%s'}", name, alias);
     }
 
     // =========================================================================
     // Builder for image configurations
 
     public static class Builder {
-
-        String name,alias;
-        RunImageConfiguration runConfig;
-        BuildImageConfiguration buildConfig;
-        WatchImageConfiguration watchConfig;
-
-        Map<String,String> externalConfig;
+        private ImageConfiguration config = new ImageConfiguration();
 
         public Builder name(String name) {
-            this.name = name;
+            config.name = name;
             return this;
         }
 
         public Builder alias(String alias) {
-            this.alias = alias;
+            config.alias = alias;
             return this;
         }
 
         public Builder runConfig(RunImageConfiguration runConfig) {
-            this.runConfig = runConfig;
+            config.run = runConfig;
             return this;
         }
 
         public Builder buildConfig(BuildImageConfiguration buildConfig) {
-            this.buildConfig = buildConfig;
+            config.build = buildConfig;
             return this;
         }
 
         public Builder externalConfig(Map<String, String> externalConfig) {
-            this.externalConfig = externalConfig;
+            config.external = externalConfig;
             return this;
         }
 
+        public Builder buildRunMode(String mode) {
+            config.mode = (mode == null) ? BuildRunMode.both : BuildRunMode.valueOf(mode);
+            return this;
+        }
+        
         public ImageConfiguration build() {
-            return new ImageConfiguration(name,alias,runConfig,buildConfig,watchConfig, externalConfig);
+            return config;
         }
 
         public Builder watchConfig(WatchImageConfiguration watchConfig) {
-            this.watchConfig = watchConfig;
+            config.watch = watchConfig;
             return this;
         }
     }

--- a/src/main/java/org/jolokia/docker/maven/config/handler/property/ConfigKey.java
+++ b/src/main/java/org/jolokia/docker/maven/config/handler/property/ConfigKey.java
@@ -33,6 +33,7 @@ public enum ConfigKey {
     ASSEMBLY_USER("assembly.user"),
     ASSEMBLY_MODE("assembly.mode"),
     BIND,
+    BUILD_RUN_MODE("mode"),
     CAP_ADD,
     CAP_DROP,
     CMD,

--- a/src/main/java/org/jolokia/docker/maven/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/org/jolokia/docker/maven/config/handler/property/PropertyConfigHandler.java
@@ -45,11 +45,13 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
 
         String name = extractName(prefix, properties);
         String alias = withPrefix(prefix, ALIAS, properties);
+        String mode = withPrefix(prefix, BUILD_RUN_MODE, properties);
         
         return Collections.singletonList(
                 new ImageConfiguration.Builder()
                         .name(name)
                         .alias(alias != null ? alias : config.getAlias())
+                        .buildRunMode(mode)
                         .runConfig(run)
                         .buildConfig(build)
                         .watchConfig(watch)

--- a/src/main/java/org/jolokia/docker/maven/model/ContainerDetails.java
+++ b/src/main/java/org/jolokia/docker/maven/model/ContainerDetails.java
@@ -14,6 +14,7 @@ public class ContainerDetails implements Container {
         this.json = json;
     }
 
+    @Override
     public String getName() {
         String name = json.getString("Name");
 
@@ -32,7 +33,8 @@ public class ContainerDetails implements Container {
 
     @Override
     public String getId() {
-        return json.getString("Id");
+        // only need first 12 to id a container
+        return json.getString("Id").substring(0, 12);
     }
 
     @Override
@@ -41,6 +43,7 @@ public class ContainerDetails implements Container {
         return json.getJSONObject("Config").getString("Image");
     }
 
+    @Override
     public boolean isRunning() {
         JSONObject state = json.getJSONObject("State");
         return state.getBoolean("Running");

--- a/src/main/java/org/jolokia/docker/maven/model/ContainersListElement.java
+++ b/src/main/java/org/jolokia/docker/maven/model/ContainersListElement.java
@@ -11,6 +11,7 @@ public class ContainersListElement implements Container {
         this.json = json;
     }
 
+    @Override
     public String getName() {
         if (json.has("Names")) {
             JSONArray names = json.getJSONArray("Names");
@@ -30,12 +31,15 @@ public class ContainersListElement implements Container {
         }
     }
 
+    @Override
     public long getCreated() {
         return json.getLong("Created");
     }
 
+    @Override
     public String getId() {
-        return json.getString("Id");
+        // only need first 12 to id a container
+        return json.getString("Id").substring(0, 12);
     }
 
     @Override
@@ -43,6 +47,7 @@ public class ContainersListElement implements Container {
         return json.getString("Image");
     }
 
+    @Override
     public boolean isRunning() {
         String status = json.getString("Status");
         return status.toLowerCase().contains("up");

--- a/src/main/java/org/jolokia/docker/maven/service/RunService.java
+++ b/src/main/java/org/jolokia/docker/maven/service/RunService.java
@@ -180,7 +180,11 @@ public class RunService {
     private List<StartOrderResolver.Resolvable> convertToResolvables(List<ImageConfiguration> images) {
         List<StartOrderResolver.Resolvable> ret = new ArrayList<>();
         for (ImageConfiguration config : images) {
-            ret.add(config);
+            if (config.getBuildRunMode().isRun()) {
+                ret.add(config);
+            } else {
+                log.info(config.getDescription() + ": Skipped, 'run' mode not enabled");
+            }
         }
         return ret;
     }
@@ -291,7 +295,7 @@ public class RunService {
     }
     
     private void startContainer(ImageConfiguration imageConfig, String id) throws DockerAccessException {
-        log.info(imageConfig.getDescription() + ": Start container " + id.substring(0, 12));
+        log.info(imageConfig.getDescription() + ": Start container " + id);
         docker.startContainer(id);
         tracker.registerShutdownAction(id, imageConfig);
     }

--- a/src/test/java/org/jolokia/docker/maven/config/handler/property/PropertyConfigHandlerTest.java
+++ b/src/test/java/org/jolokia/docker/maven/config/handler/property/PropertyConfigHandlerTest.java
@@ -42,6 +42,24 @@ public class PropertyConfigHandlerTest {
     }
 
     @Test
+    public void testBuildRunMode() {
+        ImageConfiguration buildOnly = resolveExternalImageConfig(getTestData(BuildRunMode.build));
+        assertEquals(BuildRunMode.build, buildOnly.getBuildRunMode());
+        
+        ImageConfiguration runOnly = resolveExternalImageConfig(getTestData(BuildRunMode.run));
+        assertEquals(BuildRunMode.run, runOnly.getBuildRunMode());
+
+        ImageConfiguration both = resolveExternalImageConfig(getTestData(BuildRunMode.both));
+        assertEquals(BuildRunMode.both, both.getBuildRunMode());
+        
+        ImageConfiguration skip = resolveExternalImageConfig(getTestData(BuildRunMode.skip));
+        assertEquals(BuildRunMode.skip, skip.getBuildRunMode());
+
+        ImageConfiguration notSpecified = resolveExternalImageConfig(new String[] { k(NAME), "image"});
+        assertEquals(BuildRunMode.both, notSpecified.getBuildRunMode());
+    }
+    
+    @Test
     public void testType() throws Exception {
         assertNotNull(configHandler.getType());
     }
@@ -281,6 +299,10 @@ public class PropertyConfigHandlerTest {
                 k(WAIT_URL), "http://foo.com",
                 k(WORKING_DIR), "foo"
         };
+    }
+    
+    private String[] getTestData(BuildRunMode mode) {
+        return new String[] { k(NAME), "image", k(BUILD_RUN_MODE), mode.toString() };
     }
 
     private String k(ConfigKey from) {

--- a/src/test/java/org/jolokia/docker/maven/model/ContainerTest.java
+++ b/src/test/java/org/jolokia/docker/maven/model/ContainerTest.java
@@ -33,13 +33,13 @@ public class ContainerTest {
     public void details() throws Exception {
         JSONObject data = new JSONObject();
         data.put("Created", "2015-01-06T15:47:31.485331387Z");
-        data.put("Id", "1234AF");
+        data.put("Id", "1234AF1234AF");
         data.put("Name", "/milkman-kindness");
         data.put("Config", new JSONObject("{ 'Image': '9876CE'}"));
         data.put("State", new JSONObject("{'Running' : true }"));
         Container cont = new ContainerDetails(data);
         assertEquals(1420559251485L, cont.getCreated());
-        assertEquals("1234AF", cont.getId());
+        assertEquals("1234AF1234AF", cont.getId());
         assertEquals("milkman-kindness", cont.getName());
         assertEquals("9876CE",cont.getImage());
         assertTrue(cont.isRunning());
@@ -49,12 +49,12 @@ public class ContainerTest {
     public void listElement() throws Exception {
         JSONObject data = new JSONObject();
         data.put("Created",1420559251485L);
-        data.put("Id", "1234AF");
+        data.put("Id", "1234AF1234AF");
         data.put("Image", "9876CE");
         data.put("Status", "Up 16 seconds");
         Container cont = new ContainersListElement(data);
         assertEquals(1420559251485L, cont.getCreated());
-        assertEquals("1234AF", cont.getId());
+        assertEquals("1234AF1234AF", cont.getId());
         assertEquals("9876CE", cont.getImage());
         assertTrue(cont.isRunning());
 


### PR DESCRIPTION
- allow 'build' and/or 'run' configuration to be skipped during build
- fixed model classes to only return first 12 of container id

Signed-off-by: Jae Gangemi <jgangemi@gmail.com>