### PR TITLE
Add functionality to wait.url to specify which http method to use when waiting

### DIFF
--- a/src/main/java/org/jolokia/docker/maven/StartMojo.java
+++ b/src/main/java/org/jolokia/docker/maven/StartMojo.java
@@ -43,7 +43,7 @@ public class StartMojo extends AbstractDockerMojo {
      * @parameter property = "docker.follow" default-value = "false"
      */
     protected boolean follow;
- 
+
     /**
      * {@inheritDoc}
      */
@@ -53,7 +53,7 @@ public class StartMojo extends AbstractDockerMojo {
 
         QueryService queryService = serviceHub.getQueryService();
         RunService runService = serviceHub.getRunService();
-        
+
         LogDispatcher dispatcher = getLogDispatcher(dockerAccess);
 
         boolean success = false;
@@ -98,7 +98,7 @@ public class StartMojo extends AbstractDockerMojo {
             }
         }
     }
-    
+
     private void updateDynamicPortProperties(DockerAccess docker, String containerId, RunImageConfiguration runConfig, PortMapping mappedPorts, Properties properties) throws DockerAccessException, MojoExecutionException {
         if (mappedPorts.containsDynamicPorts()) {
             mappedPorts.updateVariablesWithDynamicPorts(docker.queryContainerPortMapping(containerId));
@@ -118,7 +118,8 @@ public class StartMojo extends AbstractDockerMojo {
             ArrayList<String> logOut = new ArrayList<>();
             if (wait.getUrl() != null) {
                 String waitUrl = StrSubstitutor.replace(wait.getUrl(), projectProperties);
-                checkers.add(new WaitUtil.HttpPingChecker(waitUrl));
+                String waitMethod = StrSubstitutor.replace(wait.getMethod(), projectProperties);
+                checkers.add(new WaitUtil.HttpPingChecker(waitUrl, waitMethod));
                 logOut.add("on url " + waitUrl);
             }
             if (wait.getLog() != null) {

--- a/src/main/java/org/jolokia/docker/maven/config/WaitConfiguration.java
+++ b/src/main/java/org/jolokia/docker/maven/config/WaitConfiguration.java
@@ -16,6 +16,7 @@ public class WaitConfiguration {
      */
     private String url;
 
+    private String method;
     /**
      * @parameter
      */
@@ -28,9 +29,10 @@ public class WaitConfiguration {
 
     public WaitConfiguration() {}
 
-    private WaitConfiguration(int time, String url, String log, int shutdown) {
+    private WaitConfiguration(int time, String url, String method, String log, int shutdown) {
         this.time = time;
         this.url = url;
+        this.method = method;
         this.log = log;
         this.shutdown = shutdown;
     }
@@ -41,6 +43,10 @@ public class WaitConfiguration {
 
     public String getUrl() {
         return url;
+    }
+
+    public String getMethod() {
+        return method;
     }
 
     public String getLog() {
@@ -56,6 +62,7 @@ public class WaitConfiguration {
     public static class Builder {
         private int time = 0,shutdown = 0;
         private String url,log;
+        private String method;
 
         public Builder time(int time) {
             this.time = time;
@@ -64,6 +71,11 @@ public class WaitConfiguration {
 
         public Builder url(String url) {
             this.url = url;
+            return this;
+        }
+
+        public Builder method(String method) {
+            this.method = method;
             return this;
         }
 
@@ -78,7 +90,7 @@ public class WaitConfiguration {
         }
 
         public WaitConfiguration build() {
-            return new WaitConfiguration(time,url,log,shutdown);
+            return new WaitConfiguration(time,url,method,log,shutdown);
         }
     }
 }

--- a/src/main/java/org/jolokia/docker/maven/config/handler/property/ConfigKey.java
+++ b/src/main/java/org/jolokia/docker/maven/config/handler/property/ConfigKey.java
@@ -67,6 +67,7 @@ public enum ConfigKey {
     WAIT_LOG("wait.log"),
     WAIT_TIME("wait.time"),
     WAIT_URL("wait.url"),
+    WAIT_METHOD("wait.method"),
     WAIT_SHUTDOWN("wait.shutdown"),
     WATCH_INTERVAL("watch.interval"),
     WATCH_MODE("watch.mode"),

--- a/src/main/java/org/jolokia/docker/maven/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/org/jolokia/docker/maven/config/handler/property/PropertyConfigHandler.java
@@ -160,6 +160,7 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
         return new WaitConfiguration.Builder()
                 .time(asInt(withPrefix(prefix, WAIT_TIME,properties)))
                 .url(withPrefix(prefix, WAIT_URL, properties))
+                .method(withPrefix(prefix, WAIT_METHOD, properties))
                 .log(withPrefix(prefix, WAIT_LOG, properties))
                 .shutdown(asInt(withPrefix(prefix,WAIT_SHUTDOWN,properties)))
                 .build();

--- a/src/main/java/org/jolokia/docker/maven/util/WaitUtil.java
+++ b/src/main/java/org/jolokia/docker/maven/util/WaitUtil.java
@@ -6,6 +6,8 @@ import java.util.concurrent.TimeoutException;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpHead;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 
@@ -15,7 +17,7 @@ import org.apache.http.impl.client.HttpClientBuilder;
  */
 public class WaitUtil {
 
-     // how long to wait at max when doing a http ping
+    // how long to wait at max when doing a http ping
     private static final long HARD_MAX_WAIT = 10 * 1000;
 
     // How long to wait between pings
@@ -23,6 +25,7 @@ public class WaitUtil {
 
     // Timeout for ping
     private static final int HTTP_PING_TIMEOUT = 500;
+    public static final String DEFAULT_HTTP_METHOD = "HEAD";
 
     private WaitUtil() {}
 
@@ -79,14 +82,17 @@ public class WaitUtil {
     public static class HttpPingChecker implements WaitChecker {
 
         private String url;
+        private String method;
 
         /**
          * Ping the given URL
          *
          * @param url URL to check
+         * @param method
          */
-        public HttpPingChecker(String url) {
+        public HttpPingChecker(String url, String method) {
             this.url = url;
+            this.method = method;
         }
 
         @Override
@@ -109,7 +115,10 @@ public class WaitUtil {
                     .setDefaultRequestConfig(requestConfig)
                     .build();
             try {
-                CloseableHttpResponse response = httpClient.execute(new HttpHead(url));
+                if (method == null) {
+                    method = DEFAULT_HTTP_METHOD;
+                }
+                CloseableHttpResponse response = httpClient.execute(RequestBuilder.create(method).setUri(url).build());
                 try {
                     int responseCode = response.getStatusLine().getStatusCode();
                     return (responseCode >= 200 && responseCode <= 399);


### PR DESCRIPTION
Currently wait.url defaults to using http method 'HEAD'. 
However sometimes using a different http method is required. 
For e.g. if spinning up a container running a spring-boot application to perform integration tests against, exposes 'health' endpoints (it accepts 'GET' not 'HEAD').

If no 'method' is specified in the wait configuration it will default to 'HEAD'. Thus it should be backwards compatible.
i.e.  the following will default to using 'HEAD'

```xml                              
<wait>
  <url>http://localhost/health</url>                                
</wait>
```
and the following will use 'GET'

```xml
<wait>
  <url>http://localhost/health</url>
  <method>GET</method>                                
</wait>
```