### PR TITLE
#253: explicit exec arguments for run.cmd and run.entrypoint

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,6 +1,7 @@
 # ChangeLog
 
 * **0.13.4**
+  - Support explicit exec arguments for `start.cmd` and `start.entrypoint`. (#253) 
   - Fix processing of split chunked JSON responses (#259)
   - Fix for default registry handling. Again and again. (#261)
   - Allow `runCmds` to be compressed into a single command with the build config option `optimise`. (#263)

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -394,6 +394,24 @@ or
  </entryPoint>
 ```
 
+Shorter forms supported:
+
+```xml
+<!-- shell form  -->
+ <entryPoint>java -jar $HOME/server.jar</entryPoint>
+```
+
+or 
+
+```xml
+ <entryPoint>
+    <!-- exec form  -->
+    <arg>java</arg>
+    <arg>-jar</arg>
+    <arg>/opt/demo/server.jar</arg>
+ </entryPoint>
+```
+
 ##### Docker Assembly
 
 With using the `inline`, `descriptor` or `descriptorRef` option
@@ -509,11 +527,11 @@ The `<run>` configuration knows the following sub elements:
   from the container.
 * **command** is a command which should be executed at the end of the
   container's startup. If not given, the image's default command is
-  used. 
+  used. See [Start-up Arguments](#start-up-arguments) for details.
 * **domainname** (*v1.12*) domain name for the container
 * **dns** (*v1.11*) list of `host` elements specifying dns servers for the container to use
 * **dnsSearch** (*v1.15*) list of `host` elements specying dns search domains 
-* **entrypoint** (*v1.15*) set the entry point for the container
+* **entrypoint** (*v1.15*) set the entry point for the container. See [Start-up Arguments](#start-up-arguments) for details.
 * **env** can contain environment variables as subelements which are
   set during startup of the container. They are specified in the
   typical maven property format as described [below](#setting-environment-variables-and-labels).

--- a/src/main/java/org/jolokia/docker/maven/AbstractBuildSupportMojo.java
+++ b/src/main/java/org/jolokia/docker/maven/AbstractBuildSupportMojo.java
@@ -50,9 +50,8 @@ abstract public class AbstractBuildSupportMojo extends AbstractDockerMojo {
                                   sourceDirectory, outputDirectory);
     }
 
-    protected void buildImage(DockerAccess dockerAccess, String imageName, ImageConfiguration imageConfig)
+    protected void buildImage(DockerAccess dockerAccess, ImageConfiguration imageConfig)
             throws DockerAccessException, MojoExecutionException {
-        warnIfDeprecatedCommandConfigIsUsed(imageConfig.getBuildConfiguration());
 
         autoPullBaseImage(dockerAccess, imageConfig);
 
@@ -72,22 +71,6 @@ abstract public class AbstractBuildSupportMojo extends AbstractDockerMojo {
         }
         if (fromImage != null) {
             checkImageWithAutoPull(dockerAccess, fromImage, new ImageName(fromImage).getRegistry(),true);
-        }
-    }
-
-    private void warnIfDeprecatedCommandConfigIsUsed(BuildImageConfiguration buildConfiguration) {
-        if (buildConfiguration.getCommand() != null) {
-            log.warn("<command> in the <build> configuration is deprecated and will be be removed soon");
-            log.warn("Please use <cmd> with nested <shell> or <exec> sections instead.");
-            log.warn("");
-            log.warn("More on this is explained in the user manual: ");
-            log.warn("https://github.com/rhuss/docker-maven-plugin/blob/master/doc/manual.md#start-up-arguments");
-            log.warn("");
-            log.warn("Migration is trivial, see changelog to version 0.12.0 -->");
-            log.warn("https://github.com/rhuss/docker-maven-plugin/blob/master/doc/changelog.md");
-            log.warn("");
-            log.warn("For now, the command is automatically translated for you to the shell form:");
-            log.warn("   <cmd><shell>" + buildConfiguration.getCommand() + "</shell></cmd>");
         }
     }
 }

--- a/src/main/java/org/jolokia/docker/maven/AbstractDockerMojo.java
+++ b/src/main/java/org/jolokia/docker/maven/AbstractDockerMojo.java
@@ -165,6 +165,8 @@ public abstract class AbstractDockerMojo extends AbstractMojo implements Context
         if (!skip) {
             log = new AnsiLogger(getLog(), useColor, verbose);
 
+            validateConfiguration(log);
+
             String dockerUrl = EnvUtil.extractUrl(dockerHost);
             DockerAccess access = createDockerAccess(dockerUrl);
             setDockerHostAddressProperty(dockerUrl);
@@ -177,6 +179,12 @@ public abstract class AbstractDockerMojo extends AbstractMojo implements Context
             } finally {
                 access.shutdown();
             }
+        }
+    }
+
+    private void validateConfiguration(Logger log) {
+        for (ImageConfiguration imageConfiguration : images) {
+            imageConfiguration.validate(log);
         }
     }
 

--- a/src/main/java/org/jolokia/docker/maven/BuildMojo.java
+++ b/src/main/java/org/jolokia/docker/maven/BuildMojo.java
@@ -34,19 +34,17 @@ public class BuildMojo extends AbstractBuildSupportMojo {
                 if (buildConfig.skip()) {
                     log.info(imageConfig.getDescription() + ": Skipped building");
                 } else {
-                    buildImage(dockerAccess, imageConfig, buildConfig);
+                    buildAndTag(dockerAccess, imageConfig);
                 }
             }
         }
     }
 
-    private void buildImage(DockerAccess dockerAccess, ImageConfiguration imageConfig, BuildImageConfiguration buildConfig)
+    private void buildAndTag(DockerAccess dockerAccess, ImageConfiguration imageConfig)
         throws MojoExecutionException, DockerAccessException {
-        buildConfig.validate();
-        String imageName = imageConfig.getName();
-        buildImage(dockerAccess, imageName, imageConfig);
+        buildImage(dockerAccess, imageConfig);
         if (!skipTags) {
-            tagImage(imageName, imageConfig, dockerAccess);
+            tagImage(imageConfig.getName(), imageConfig, dockerAccess);
         }
     }
     

--- a/src/main/java/org/jolokia/docker/maven/WatchMojo.java
+++ b/src/main/java/org/jolokia/docker/maven/WatchMojo.java
@@ -145,7 +145,7 @@ public class WatchMojo extends AbstractBuildSupportMojo {
                     try {
                         log.info(imageConfig.getDescription() + ": Assembly changed. Rebuild ...");
                         // Rebuild whole image for now ...
-                        buildImage(docker, name, imageConfig);
+                        buildImage(docker, imageConfig);
 
                         watcher.setImageId(serviceHub.getQueryService().getImageId(name));
                         if (doRestart) {

--- a/src/main/java/org/jolokia/docker/maven/access/ContainerCreateConfig.java
+++ b/src/main/java/org/jolokia/docker/maven/access/ContainerCreateConfig.java
@@ -4,7 +4,7 @@ import java.io.*;
 import java.util.*;
 
 import org.apache.commons.lang3.text.StrSubstitutor;
-import org.jolokia.docker.maven.util.EnvUtil;
+import org.jolokia.docker.maven.config.Arguments;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -30,9 +30,9 @@ public class ContainerCreateConfig {
         return this;
     }
 
-    public ContainerCreateConfig command(String command) {
+    public ContainerCreateConfig command(Arguments command) {
         if (command != null) {
-            createConfig.put("Cmd", splitOnWhiteSpace(command));
+            createConfig.put("Cmd", new JSONArray(command.asStrings()));
         }
         return this;
     }
@@ -41,19 +41,11 @@ public class ContainerCreateConfig {
         return add("Domainname", domainname);
     }
 
-    public ContainerCreateConfig entrypoint(String entrypoint) {
+    public ContainerCreateConfig entrypoint(Arguments entrypoint) {
         if (entrypoint != null) {
-            createConfig.put("Entrypoint", splitOnWhiteSpace(entrypoint));
+            createConfig.put("Entrypoint", new JSONArray(entrypoint.asStrings()));
         }
         return this;
-    }
-
-    private JSONArray splitOnWhiteSpace(String entrypoint) {
-        JSONArray a = new JSONArray();
-        for (String s : EnvUtil.splitOnSpaceWithEscape(entrypoint)) {
-            a.put(s);
-        }
-        return a;
     }
 
     public ContainerCreateConfig environment(String envPropsFile, Map<String, String> env, Map mavenProps) throws IllegalArgumentException {

--- a/src/main/java/org/jolokia/docker/maven/assembly/DockerFileBuilder.java
+++ b/src/main/java/org/jolokia/docker/maven/assembly/DockerFileBuilder.java
@@ -253,13 +253,11 @@ public class DockerFileBuilder {
     }
 
     public DockerFileBuilder cmd(Arguments cmd) {
-        cmd.validate();
         this.cmd = cmd;
         return this;
     }
 
     public DockerFileBuilder entryPoint(Arguments entryPoint) {
-        entryPoint.validate();
         this.entryPoint = entryPoint;
         return this;
     }

--- a/src/main/java/org/jolokia/docker/maven/config/Arguments.java
+++ b/src/main/java/org/jolokia/docker/maven/config/Arguments.java
@@ -1,7 +1,8 @@
 package org.jolokia.docker.maven.config;
 
-import java.util.ArrayList;
-import java.util.List;
+import org.jolokia.docker.maven.util.EnvUtil;
+
+import java.util.*;
 
 public class Arguments {
 
@@ -15,6 +16,53 @@ public class Arguments {
      */
     private List<String> exec;
 
+    /**
+     * Used to distinguish between shorter version
+     *
+     * <pre>
+     *   &lt;cmd&gt;
+     *     &lt;arg&gt;echo&lt;/arg&gt;
+     *     &lt;arg&gt;Hello, world!&lt;/arg&gt;
+     *   &lt;/cmd&gt;
+     * </pre>
+     *
+     * from the full one
+     *
+     * <pre>
+     *   &lt;cmd&gt;
+     *     &lt;exec&gt;
+     *       &lt;arg&gt;echo&lt;/arg&gt;
+     *       &lt;arg&gt;Hello, world!&lt;/arg&gt;
+     *     &lt;exec&gt;
+     *   &lt;/cmd&gt;
+     * </pre>
+     *
+     * and throw a validation error if both specified.
+     */
+    private List<String> execInlined = new ArrayList<>();
+
+    public Arguments() {
+        this(null);
+    }
+
+    public Arguments(String shell) {
+        this.shell = shell;
+    }
+
+    /**
+     * Used to support shell specified as a default parameter, e.g.
+     *
+     * <pre>
+     *   &lt;cmd&gt;java -jar $HOME/server.jar&lt;/cmd&gt;
+     * </pre>
+     *
+     * Read <a href="http://blog.sonatype.com/2011/03/configuring-plugin-goals-in-maven-3/#.VeR3JbQ56Rv">more</a> on this and other useful techniques.
+     *
+     */
+    public void set(String shell) {
+        setShell(shell);
+    }
+
     public void setShell(String shell) {
         this.shell = shell;
     }
@@ -27,17 +75,43 @@ public class Arguments {
         this.exec = exec;
     }
 
+    /**
+     * @see Arguments#execInlined
+     */
+    @SuppressWarnings("unused")
+    public void setArg(String arg) {
+        this.execInlined.add(arg);
+    }
+
     public List<String> getExec() {
-        return exec;
+        return exec == null ? execInlined : exec;
     }
 
     public void validate() throws IllegalArgumentException {
-        if (shell == null && (exec == null || exec.isEmpty())){
-            throw new IllegalArgumentException("Argument conflict, either shell or params should be specified");
+        int valueSources = 0;
+        if (shell != null) {
+            valueSources ++;
         }
-        if (shell != null && exec != null) {
-            throw new IllegalArgumentException("Argument conflict, either shell or params should be specified");
+        if (exec != null && !exec.isEmpty()) {
+            valueSources ++;
         }
+        if (!execInlined.isEmpty()) {
+            valueSources ++;
+        }
+
+        if (valueSources != 1){
+            throw new IllegalArgumentException("Argument conflict: either shell or args should be specified and only in one form.");
+        }
+    }
+
+    public List<String> asStrings() {
+        if (shell != null) {
+            return Arrays.asList(EnvUtil.splitOnSpaceWithEscape(shell));
+        }
+        if (exec != null) {
+            return Collections.unmodifiableList(exec);
+        }
+        return Collections.unmodifiableList(execInlined);
     }
 
     public static class Builder {

--- a/src/main/java/org/jolokia/docker/maven/config/BuildImageConfiguration.java
+++ b/src/main/java/org/jolokia/docker/maven/config/BuildImageConfiguration.java
@@ -2,7 +2,7 @@ package org.jolokia.docker.maven.config;
 
 import java.util.*;
 
-import org.apache.maven.plugin.MojoExecutionException;
+import org.jolokia.docker.maven.util.Logger;
 
 /**
  * @author roland
@@ -274,12 +274,27 @@ public class BuildImageConfiguration {
         }
     }
 
-    public void validate() throws MojoExecutionException {
+    public void validate(Logger log) throws IllegalArgumentException {
         if (entryPoint != null) {
             entryPoint.validate();
         }
         if (cmd != null) {
             cmd.validate();
         }
+
+        if (command != null) {
+            log.warn("<command> in the <build> configuration is deprecated and will be be removed soon");
+            log.warn("Please use <cmd> with nested <shell> or <exec> sections instead.");
+            log.warn("");
+            log.warn("More on this is explained in the user manual: ");
+            log.warn("https://github.com/rhuss/docker-maven-plugin/blob/master/doc/manual.md#start-up-arguments");
+            log.warn("");
+            log.warn("Migration is trivial, see changelog to version 0.12.0 -->");
+            log.warn("https://github.com/rhuss/docker-maven-plugin/blob/master/doc/changelog.md");
+            log.warn("");
+            log.warn("For now, the command is automatically translated for you to the shell form:");
+            log.warn("   <cmd>" + command + "</cmd>");
+        }
+
     }
 }

--- a/src/main/java/org/jolokia/docker/maven/config/ImageConfiguration.java
+++ b/src/main/java/org/jolokia/docker/maven/config/ImageConfiguration.java
@@ -3,6 +3,7 @@ package org.jolokia.docker.maven.config;
 import java.util.*;
 
 import org.jolokia.docker.maven.util.EnvUtil;
+import org.jolokia.docker.maven.util.Logger;
 import org.jolokia.docker.maven.util.StartOrderResolver;
 
 /**
@@ -123,6 +124,15 @@ public class ImageConfiguration implements StartOrderResolver.Resolvable {
     @Override
     public String toString() {
         return String.format("ImageConfiguration {name='%s', alias='%s'}", name, alias);
+    }
+
+    public void validate(Logger log) {
+        if (null != build) {
+            build.validate(log);
+        }
+        if (null != run) {
+            run.validate();
+        }
     }
 
     // =========================================================================

--- a/src/main/java/org/jolokia/docker/maven/config/RunImageConfiguration.java
+++ b/src/main/java/org/jolokia/docker/maven/config/RunImageConfiguration.java
@@ -35,7 +35,7 @@ public class RunImageConfiguration {
     /**
      * @parameter
      */
-    private String cmd;
+    private Arguments cmd;
 
     // container domain name
     /**
@@ -47,7 +47,7 @@ public class RunImageConfiguration {
     /**
      * @parameter
      */
-    private String entrypoint;
+    private Arguments entrypoint;
 
     // container hostname
     /**
@@ -125,6 +125,15 @@ public class RunImageConfiguration {
     /** @parameter */
     private NamingStrategy namingStrategy;
 
+    public void validate() {
+        if (entrypoint != null) {
+            entrypoint.validate();
+        }
+        if (cmd != null) {
+            cmd.validate();
+        }
+    }
+
     // Naming scheme for how to name container
     public enum NamingStrategy {
         none,  // No extra naming
@@ -178,7 +187,7 @@ public class RunImageConfiguration {
         return envPropertyFile;
     }
 
-    public String getEntrypoint() {
+    public Arguments getEntrypoint() {
         return entrypoint;
     }
 
@@ -206,7 +215,7 @@ public class RunImageConfiguration {
         return (ports != null) ? ports : Collections.<String>emptyList();
     }
 
-    public String getCmd() {
+    public Arguments getCmd() {
         return cmd;
     }
 
@@ -293,7 +302,7 @@ public class RunImageConfiguration {
         }
 
         public Builder cmd(String cmd) {
-            config.cmd = cmd;
+            config.cmd = new Arguments(cmd);
             return this;
         }
 
@@ -303,7 +312,7 @@ public class RunImageConfiguration {
         }
 
         public Builder entrypoint(String entrypoint) {
-            config.entrypoint = entrypoint;
+            config.entrypoint = new Arguments(entrypoint);
             return this;
         }
 

--- a/src/test/java/integration/DockerAccessIT.java
+++ b/src/test/java/integration/DockerAccessIT.java
@@ -10,6 +10,7 @@ import org.apache.maven.plugin.logging.SystemStreamLog;
 import org.jolokia.docker.maven.AbstractDockerMojo;
 import org.jolokia.docker.maven.access.*;
 import org.jolokia.docker.maven.access.hc.DockerAccessWithHcClient;
+import org.jolokia.docker.maven.config.Arguments;
 import org.jolokia.docker.maven.model.Container.PortBinding;
 import org.jolokia.docker.maven.util.*;
 import org.junit.*;
@@ -84,7 +85,7 @@ public class DockerAccessIT {
     private void testCreateContainer() throws DockerAccessException {
         PortMapping portMapping = new PortMapping(Arrays.asList(new Object[] { PORT + ":" + PORT }), new Properties());
         ContainerHostConfig hostConfig = new ContainerHostConfig().portBindings(portMapping);
-        ContainerCreateConfig createConfig = new ContainerCreateConfig(IMAGE).command("ping google.com").hostConfig(hostConfig);
+        ContainerCreateConfig createConfig = new ContainerCreateConfig(IMAGE).command(new Arguments("ping google.com")).hostConfig(hostConfig);
 
         containerId = dockerClient.createContainer(createConfig, CONTAINER_NAME);
         assertNotNull(containerId);

--- a/src/test/java/org/jolokia/docker/maven/config/handler/property/PropertyConfigHandlerTest.java
+++ b/src/test/java/org/jolokia/docker/maven/config/handler/property/PropertyConfigHandlerTest.java
@@ -221,11 +221,11 @@ public class PropertyConfigHandlerTest {
         assertEquals(a("/foo", "/tmp:/tmp"), runConfig.getVolumeConfiguration().getBind());
         assertEquals(a("CAP"), runConfig.getCapAdd());
         assertEquals(a("CAP"), runConfig.getCapDrop());
-        assertEquals("command.sh", runConfig.getCmd());
+        assertEquals("command.sh", runConfig.getCmd().getShell());
         assertEquals(a("8.8.8.8"), runConfig.getDns());
         assertEquals(a("example.com"), runConfig.getDnsSearch());
         assertEquals("domain.com", runConfig.getDomainname());
-        assertEquals("entrypoint.sh", runConfig.getEntrypoint());
+        assertEquals("entrypoint.sh", runConfig.getEntrypoint().getShell());
         assertEquals(a("localhost:127.0.0.1"), runConfig.getExtraHosts());
         assertEquals("subdomain", runConfig.getHostname());
         assertEquals(a("redis"), runConfig.getLinks());


### PR DESCRIPTION
fixes #253 

* explicit exec arguments for run.cmd and run.entrypoint
* refactored Arguments validation: invoked before mojo executions; includes deprecation message; on the downside revalidated for every mojo.
* refactored Arguments to support shortcuts `<cmd>blah</cmd>` and `<cmd><arg>blah</arg><arg>fooe</arg></cmd>`

Feel free to ask for documentation changes and better tests coverage. 

pom.xml used for integration (with maven) testing: https://gist.github.com/mgurov/8c9c991d95b5a95b91ff