### PR TITLE
Add logic to specify exec commands during postStart and preStop

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -13,6 +13,7 @@
   - HTTP method and status code can be specified when waiting on an HTTP URL (#258)
   - Introduced global `portPropertyFile` setting (#90)
   - Allow the container's host ip to be bound to a maven property and exported
+  - Add logic to specify exec commands during postStart and preStop (#272)
 
 * **0.13.2**
   - "run" directives can be added to the Dockerfile (#191)

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -806,7 +806,10 @@ some condition is met. These conditions can be specified within a
 * **shutdown** is the time to wait in milliseconds between stopping a container
   and removing it. This might be helpful in situation where a Docker croaks with an
   error when trying to remove a container to fast after it has been stopped.
-
+* **exec** Specifies commands to execute during specified lifecycle of the container. It knows the following sub-elements:
+  - **postStart** Command to run after the above wait criteria has been met
+  - **preStop** Command to run before the container is stopped.
+  
 As soon as one condition is met the build continues. If you add a
 `<time>` constraint this works more or less as a timeout for other
 conditions. The build will abort if you wait on an url or log output and reach the timeout. 
@@ -823,6 +826,10 @@ Example:
   </http>
   <time>10000</time>
   <shutdown>500</shutdown>
+  <exec>
+     <postStart>/opt/init_db.sh</postStart>
+     <preStop>/opt/notify_end.sh</preStop>
+  </exec>
 </wait>
 ```` 
 

--- a/src/main/java/org/jolokia/docker/maven/StartMojo.java
+++ b/src/main/java/org/jolokia/docker/maven/StartMojo.java
@@ -93,6 +93,10 @@ public class StartMojo extends AbstractDockerMojo {
 
                 // Wait if requested
                 waitIfRequested(dockerAccess,imageConfig, projProperties, containerId);
+                WaitConfiguration waitConfig = runConfig.getWaitConfiguration();
+                if (waitConfig != null && waitConfig.getExec() != null && waitConfig.getExec().getPostStart() != null) {
+                    runService.createAndStartExecContainer(containerId, waitConfig.getExec().getPostStart());
+                }
             }
             if (follow) {
                 runService.addShutdownHookForStoppingContainers(keepContainer,removeVolumes);

--- a/src/main/java/org/jolokia/docker/maven/access/DockerAccess.java
+++ b/src/main/java/org/jolokia/docker/maven/access/DockerAccess.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.jolokia.docker.maven.access.log.LogCallback;
 import org.jolokia.docker.maven.access.log.LogGetHandle;
+import org.jolokia.docker.maven.config.Arguments;
 import org.jolokia.docker.maven.model.*;
 
 /**
@@ -49,10 +50,28 @@ public interface DockerAccess {
      * @throws DockerAccessException if the containers could not be listed
      */
     List<Container> listContainers(int limit) throws DockerAccessException;
-    
+    /**
+     * Starts a previously set up exec instance id.
+     * this API sets up an interactive session with the exec command
+     *
+     * @param containerId id of the exec container
+     * @return stdout/stderr of running the exec container
+     * @throws DockerAccessException if the container could not be created.
+     */
+    String startExecContainer(String containerId) throws DockerAccessException;
+
+    /**
+     * Sets up an exec instance for a running container id
+     *
+     * @param arguments container exec commands to run
+     * @param containerId id of the running container which the exec container will be created for
+     * @throws DockerAccessException if the container could not be created.
+     */
+    String createExecContainer(Arguments arguments, String containerId) throws DockerAccessException;
+
     /**
      * Create a container from the given image.
-     * 
+     *
      * <p>The <code>container id</code> will be set on the <code>container</code> upon successful creation.</p>
      *
      * @param configuration container configuration
@@ -60,7 +79,7 @@ public interface DockerAccess {
      * @throws DockerAccessException if the container could not be created.
      */
     String createContainer(ContainerCreateConfig configuration, String containerName) throws DockerAccessException;
-    
+
     /**
      * Start a container.
      *

--- a/src/main/java/org/jolokia/docker/maven/access/UrlBuilder.java
+++ b/src/main/java/org/jolokia/docker/maven/access/UrlBuilder.java
@@ -76,6 +76,14 @@ public final class UrlBuilder {
         return u("containers/%s/start", containerId).toString();
     }
 
+    public String createExecContainer(String containerId) {
+        return u("containers/%s/exec", containerId).url;
+    }
+
+    public String startExecContainer(String containerId) {
+        return u("exec/%s/start", containerId).url;
+    }
+
     public String stopContainer(String containerId) {
         return u("containers/%s/stop", containerId).toString();
     }

--- a/src/main/java/org/jolokia/docker/maven/access/hc/DockerAccessWithHcClient.java
+++ b/src/main/java/org/jolokia/docker/maven/access/hc/DockerAccessWithHcClient.java
@@ -1,21 +1,31 @@
 package org.jolokia.docker.maven.access.hc;
 
-import java.io.*;
-import java.net.URI;
-import java.util.*;
-
 import org.apache.http.HttpResponse;
 import org.apache.http.client.ResponseHandler;
 import org.jolokia.docker.maven.access.*;
 import org.jolokia.docker.maven.access.chunked.*;
 import org.jolokia.docker.maven.access.hc.http.HttpClientBuilder;
 import org.jolokia.docker.maven.access.hc.unix.UnixSocketClientBuilder;
-import org.jolokia.docker.maven.access.log.*;
-import org.jolokia.docker.maven.model.*;
+import org.jolokia.docker.maven.access.log.LogCallback;
+import org.jolokia.docker.maven.access.log.LogGetHandle;
+import org.jolokia.docker.maven.access.log.LogRequestor;
+import org.jolokia.docker.maven.config.Arguments;
+import org.jolokia.docker.maven.model.Container;
+import org.jolokia.docker.maven.model.ContainerDetails;
+import org.jolokia.docker.maven.model.ContainersListElement;
 import org.jolokia.docker.maven.util.ImageName;
 import org.jolokia.docker.maven.util.Logger;
 import org.json.JSONArray;
 import org.json.JSONObject;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 import static java.net.HttpURLConnection.*;
 import static org.jolokia.docker.maven.access.hc.ApacheHttpClientDelegate.*;
@@ -69,6 +79,48 @@ public class DockerAccessWithHcClient implements DockerAccess {
                             new HttpClientBuilder(isSSL(baseUrl) ? certPath : null).build(maxConnections));
             this.urlBuilder = new UrlBuilder(baseUrl, apiVersion);
         }
+    }
+
+    @Override
+    public String startExecContainer(String containerId) throws DockerAccessException {
+        try {
+            String url = urlBuilder.startExecContainer(containerId);
+            JSONObject request = new JSONObject();
+            request.put("Detach", false);
+            request.put("Tty", false);
+
+            return delegate.post(url, request.toString(), new BodyResponseHandler(), HTTP_OK);
+        } catch (Exception e) {
+            log.error(e.getMessage());
+            throw new DockerAccessException("Unable to start container id [%s]", containerId);
+        }
+    }
+
+    @Override
+    public String createExecContainer(Arguments arguments, String containerId) throws DockerAccessException {
+        String url = urlBuilder.createExecContainer(containerId);
+        JSONObject request = new JSONObject();
+        request.put("Tty", false);
+        request.put("AttachStdin", true);
+        request.put("AttachStdout", true);
+        request.put("AttachStderr", true);
+        request.put("Cmd", arguments.getExec());
+
+        String execJsonRequest = request.toString();
+        try {
+            String response = delegate.post(url, execJsonRequest, new BodyResponseHandler(), HTTP_CREATED);
+            JSONObject json = new JSONObject(response);
+            if (json.has("Warnings")) {
+                logWarnings(json);
+            }
+
+            return json.getString("Id");
+        } catch (IOException e) {
+            log.error(e.getMessage());
+            throw new DockerAccessException("Unable to exec [%s] on container [%s]", request.toString(),
+                    containerId);
+        }
+
     }
 
     @Override
@@ -126,7 +178,7 @@ public class DockerAccessWithHcClient implements DockerAccess {
             throw new DockerAccessException("Unable to build image [%s]", image);
         }
     }
-    
+
     @Override
     public void getLogSync(String containerId, LogCallback callback) {
         LogRequestor
@@ -229,7 +281,7 @@ public class DockerAccessWithHcClient implements DockerAccess {
                           createPullOrPushResponseHandler(), HTTP_OK);
         } catch (IOException e) {
             log.error(e.getMessage());
-            throw new DockerAccessException("Unable to pull '%s'%s", image, (registry != null) ? " from registry '" + registry + "'" : ""); 
+            throw new DockerAccessException("Unable to pull '%s'%s", image, (registry != null) ? " from registry '" + registry + "'" : "");
         }
     }
 
@@ -244,7 +296,7 @@ public class DockerAccessWithHcClient implements DockerAccess {
                           createPullOrPushResponseHandler(), HTTP_OK);
         } catch (IOException e) {
             log.error(e.getMessage());
-            throw new DockerAccessException("Unable to push '%s'%s", image, (registry != null) ? " from registry '" + registry + "'" : ""); 
+            throw new DockerAccessException("Unable to push '%s'%s", image, (registry != null) ? " from registry '" + registry + "'" : "");
         } finally {
             if (temporaryImage != null) {
                 removeImage(temporaryImage);

--- a/src/main/java/org/jolokia/docker/maven/config/WaitConfiguration.java
+++ b/src/main/java/org/jolokia/docker/maven/config/WaitConfiguration.java
@@ -25,6 +25,11 @@ public class WaitConfiguration {
     /**
      * @parameter
      */
+    private ExecConfiguration exec;
+
+    /**
+     * @parameter
+     */
     private String log;
 
     /**
@@ -34,13 +39,13 @@ public class WaitConfiguration {
 
     public WaitConfiguration() {}
 
-    private WaitConfiguration(int time, HttpConfiguration http, String log, int shutdown) {
+    private WaitConfiguration(int time, ExecConfiguration exec, HttpConfiguration http, String log, int shutdown) {
         this.time = time;
+        this.exec = exec;
         this.http = http;
         this.log = log;
         this.shutdown = shutdown;
     }
-
 
     public int getTime() {
         return time;
@@ -48,6 +53,10 @@ public class WaitConfiguration {
 
     public String getUrl() {
         return http != null ? http.getUrl() : url;
+    }
+
+    public ExecConfiguration getExec() {
+        return exec;
     }
 
     public HttpConfiguration getHttp() {
@@ -68,6 +77,8 @@ public class WaitConfiguration {
         private int time = 0,shutdown = 0;
         private String url,log,status;
         private String method;
+        private String preStop;
+        private String postStart;
 
         public Builder time(int time) {
             this.time = time;
@@ -100,7 +111,40 @@ public class WaitConfiguration {
         }
 
         public WaitConfiguration build() {
-            return new WaitConfiguration(time,new HttpConfiguration(url,method,status), log,shutdown);
+            return new WaitConfiguration(time, new ExecConfiguration(postStart, preStop), new HttpConfiguration(url,method,status), log, shutdown);
+        }
+
+        public Builder preStop(String command) {
+            this.preStop = command;
+            return this;
+        }
+
+        public Builder postStart(String command) {
+            this.postStart = command;
+            return this;
+        }
+    }
+
+    public static class ExecConfiguration {
+        /** @parameter */
+        private String postStart;
+        /** @parameter */
+        private String preStop;
+
+        public ExecConfiguration() {
+        }
+
+        public ExecConfiguration(String postStart, String preStop) {
+            this.postStart = postStart;
+            this.preStop = preStop;
+        }
+
+        public String getPostStart() {
+            return postStart;
+        }
+
+        public String getPreStop() {
+            return preStop;
         }
     }
 

--- a/src/main/java/org/jolokia/docker/maven/config/handler/property/ConfigKey.java
+++ b/src/main/java/org/jolokia/docker/maven/config/handler/property/ConfigKey.java
@@ -68,6 +68,8 @@ public enum ConfigKey {
     WORKDIR,
     VOLUMES_FROM,
     WAIT_LOG("wait.log"),
+    POST_START("wait.exec.postStart"),
+    PRE_STOP("wait.exec.preStop"),
     WAIT_TIME("wait.time"),
     WAIT_URL("wait.url"),
     WAIT_HTTP_URL("wait.http.url"),

--- a/src/main/java/org/jolokia/docker/maven/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/org/jolokia/docker/maven/config/handler/property/PropertyConfigHandler.java
@@ -168,6 +168,8 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
         return new WaitConfiguration.Builder()
                 .time(asInt(withPrefix(prefix, WAIT_TIME,properties)))
                 .url(url)
+                .preStop(withPrefix(prefix, PRE_STOP, properties))
+                .postStart(withPrefix(prefix, POST_START, properties))
                 .method(withPrefix(prefix, WAIT_HTTP_METHOD, properties))
                 .status(withPrefix(prefix, WAIT_HTTP_STATUS, properties))
                 .log(withPrefix(prefix, WAIT_LOG, properties))

--- a/src/test/java/integration/DockerAccessIT.java
+++ b/src/test/java/integration/DockerAccessIT.java
@@ -5,15 +5,18 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Properties;
 
+import com.google.common.collect.Lists;
 import edu.emory.mathcs.backport.java.util.Arrays;
 import org.apache.maven.plugin.logging.SystemStreamLog;
 import org.jolokia.docker.maven.AbstractDockerMojo;
 import org.jolokia.docker.maven.access.*;
 import org.jolokia.docker.maven.access.hc.DockerAccessWithHcClient;
+import org.jolokia.docker.maven.config.Arguments;
 import org.jolokia.docker.maven.model.Container.PortBinding;
 import org.jolokia.docker.maven.util.*;
 import org.junit.*;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
 
 /*
@@ -26,13 +29,13 @@ public class DockerAccessIT {
 
     private static final String CONTAINER_NAME = "integration-test";
     private static final String IMAGE = "busybox:buildroot-2014.02";
-    
+
     private static final String IMAGE_TAG = "busybox:tagged";
     private static final int PORT = 5677;
 
     private String containerId;
     private final DockerAccessWithHcClient dockerClient;
-    
+
     public DockerAccessIT() {
         this.dockerClient = createClient(EnvUtil.extractUrl(null), new AnsiLogger(new SystemStreamLog(), true, true));
     }
@@ -43,27 +46,27 @@ public class DockerAccessIT {
         testRemoveImage(IMAGE);
         testRemoveImage(IMAGE_TAG);
     }
-    
+
     @Test
     @Ignore
     public void testBuildImage() throws DockerAccessException {
         File file = new File("src/test/resources/integration/busybox-test.tar");
         dockerClient.buildImage(IMAGE_TAG, file, false);
         assertTrue(hasImage(IMAGE_TAG));
-        
+
         testRemoveImage(IMAGE_TAG);
     }
-    
+
     @Test
     public void testPullStartStopRemove() throws DockerAccessException {
         testDoesNotHave();
-        
+
         try {
             testPullImage();
             testTagImage();
-        
             testCreateContainer();
             testStartContainer();
+            testExecContainer();
             testQueryPortMapping();
             testStopContainer();
             testRemoveContainer();
@@ -74,7 +77,7 @@ public class DockerAccessIT {
 
     private DockerAccessWithHcClient createClient(String baseUrl, Logger logger) {
         try {
-            return new DockerAccessWithHcClient(AbstractDockerMojo.API_VERSION, baseUrl, null, 20, logger);
+            return new DockerAccessWithHcClient(AbstractDockerMojo.API_VERSION, baseUrl, EnvUtil.getCertPath(null), 20, logger);
         } catch (@SuppressWarnings("unused") IOException e) {
             // not using ssl, so not going to happen
             throw new RuntimeException();
@@ -106,7 +109,7 @@ public class DockerAccessIT {
         Map<String, PortBinding> portMap = dockerClient.inspectContainer(containerId).getPortBindings();
         assertEquals(5677, portMap.values().iterator().next().getHostPort().intValue());
     }
-    
+
     private void testRemoveContainer() throws DockerAccessException {
         dockerClient.removeContainer(containerId, true);
     }
@@ -121,6 +124,13 @@ public class DockerAccessIT {
         assertTrue(dockerClient.inspectContainer(containerId).isRunning());
     }
 
+    private void testExecContainer() throws DockerAccessException {
+        Arguments arguments = new Arguments();
+        arguments.setExec(Lists.newArrayList("echo", "test", "echo"));
+        String execContainerId = dockerClient.createExecContainer(arguments, this.containerId);
+        assertThat(dockerClient.startExecContainer(execContainerId), is("test echo"));
+    }
+
     private void testStopContainer() throws DockerAccessException {
         dockerClient.stopContainer(containerId);
         assertFalse(dockerClient.inspectContainer(containerId).isRunning());
@@ -129,11 +139,11 @@ public class DockerAccessIT {
     private void testTagImage() throws DockerAccessException {
         dockerClient.tag(IMAGE, IMAGE_TAG,false);
         assertTrue(hasImage(IMAGE_TAG));
-        
+
         dockerClient.removeImage(IMAGE_TAG, false);
         assertFalse(hasImage(IMAGE_TAG));
     }
-    
+
     private boolean hasImage(String image) throws DockerAccessException {
         return dockerClient.hasImage(image);
     }

--- a/src/test/java/org/jolokia/docker/maven/config/handler/property/PropertyConfigHandlerTest.java
+++ b/src/test/java/org/jolokia/docker/maven/config/handler/property/PropertyConfigHandlerTest.java
@@ -242,6 +242,8 @@ public class PropertyConfigHandlerTest {
         WaitConfiguration wait = runConfig.getWaitConfiguration();
         assertEquals("http://foo.com", wait.getUrl());
         assertEquals("pattern", wait.getLog());
+        assertEquals("post_start_command", wait.getExec().getPostStart());
+        assertEquals("pre_stop_command", wait.getExec().getPreStop());
         assertEquals(5, wait.getTime());
     }
 
@@ -301,6 +303,8 @@ public class PropertyConfigHandlerTest {
                 k(USER), "tomcat",
                 k(VOLUMES) + ".1","/foo",
                 k(VOLUMES_FROM) + ".1", "from",
+                k(PRE_STOP), "pre_stop_command",
+                k(POST_START), "post_start_command",
                 k(WAIT_LOG), "pattern",
                 k(WAIT_TIME), "5",
                 k(WAIT_URL), "http://foo.com",


### PR DESCRIPTION
PR for #266
e.g. 
```
<wait>
  <http>
    <url>http://localhost:${host.port}</url>
    <method>GET</method>
    <status>200..399</status>
  </http>
  <time>10000</time>
  <shutdown>500</shutdown>
  <exec>
    <postStart>/opt/init_db.sh<postStart>
    <preStop>/opt/notify_end.sh</preStop>
  </exec>
</wait>
```