### PR TITLE
 #274 - report actual time waited when default maxwait for asked for

### DIFF
--- a/src/main/java/org/jolokia/docker/maven/StartMojo.java
+++ b/src/main/java/org/jolokia/docker/maven/StartMojo.java
@@ -140,8 +140,8 @@ public class StartMojo extends AbstractDockerMojo {
             try {
                 long waited = WaitUtil.wait(wait.getTime(), checkers.toArray(new WaitUtil.WaitChecker[0]));
                 log.info(imageConfig.getDescription() + ": Waited " + StringUtils.join(logOut.toArray(), " and ") + " " + waited + " ms");
-            } catch (TimeoutException exp) {
-                String desc = imageConfig.getDescription() + ": Timeout after " + wait.getTime() + " ms while waiting " +
+            } catch (WaitUtil.WaitTimeoutException exp) {
+                String desc = imageConfig.getDescription() + ": Timeout after " + exp.getWaited() + " ms while waiting " +
                               StringUtils.join(logOut.toArray(), " and ");
                 log.error(desc);
                 throw new MojoExecutionException(desc);


### PR DESCRIPTION
fixes #274

Extended `java.util.concurrent.TimeoutException` with custom `org.jolokia.docker.maven.util.WaitUtil.WaitTimeoutException` to send the actual wait time downstream. 

Could be refactored further to avoid using (checked) exceptions whatsoever upon request.