### PR TITLE
fix to add support for multiple docker services

### DIFF
--- a/doc/manual.md
+++ b/doc/manual.md
@@ -525,7 +525,7 @@ The `<run>` configuration knows the following sub elements:
   the container.
 * **capDrop** (*v1.14*) a list of `drop` elements to specify kernel parameters to remove
   from the container.
-* **command** is a command which should be executed at the end of the
+* **cmd** is a command which should be executed at the end of the
   container's startup. If not given, the image's default command is
   used. See [Start-up Arguments](#start-up-arguments) for details.
 * **domainname** (*v1.12*) domain name for the container
@@ -602,7 +602,7 @@ Example:
     <date>ISO8601</date>
     <color>blue</color>
   </log>
-  <command>java -jar /maven/docker-demo.jar</command>
+  <cmd>java -jar /maven/docker-demo.jar</cmd>
 </run>
 ````
 
@@ -1204,7 +1204,7 @@ values in the `<build>` and `<run>` sections.
 * **docker.bind.idx** Sets a list of paths to bind/expose in the container
 * **docker.capAdd.idx** List of kernel capabilities to add to the container
 * **docker.capDrop.idx** List of kernel capabilities to remove from the container
-* **docker.command** Command to execute. This is used both when
+* **docker.cmd** Command to execute. This is used both when
   running a container and as default command when creating an image.
 * **docker.domainname** Container domain name
 * **docker.dns.idx** List of dns servers to use

--- a/src/main/java/org/jolokia/docker/maven/access/DockerAccess.java
+++ b/src/main/java/org/jolokia/docker/maven/access/DockerAccess.java
@@ -189,4 +189,9 @@ public interface DockerAccess {
      * cleaning up things.
      */
     void shutdown();
+
+    /**
+     * Expose the base url of the docker service.
+     */
+    String getBaseUrl();
 }

--- a/src/main/java/org/jolokia/docker/maven/access/hc/DockerAccessWithHcClient.java
+++ b/src/main/java/org/jolokia/docker/maven/access/hc/DockerAccessWithHcClient.java
@@ -55,6 +55,7 @@ public class DockerAccessWithHcClient implements DockerAccess {
 
     private final ApacheHttpClientDelegate delegate;
     private final UrlBuilder urlBuilder;
+    private final String baseUrl;
 
     /**
      * Create a new access for the given URL
@@ -68,6 +69,7 @@ public class DockerAccessWithHcClient implements DockerAccess {
     public DockerAccessWithHcClient(String apiVersion, String baseUrl, String certPath, int maxConnections, Logger log)
             throws IOException {
         this.log = log;
+        this.baseUrl = baseUrl;
         URI uri = URI.create(baseUrl);
         if (uri.getScheme() == null) {
             throw new IllegalArgumentException("The docker access url '" + baseUrl + "' must contain a schema tcp:// or unix://");
@@ -347,6 +349,11 @@ public class DockerAccessWithHcClient implements DockerAccess {
 
     @Override
     public void shutdown() {
+    }
+
+    @Override
+    public String getBaseUrl() {
+        return baseUrl;
     }
 
     // visible for testing?

--- a/src/main/java/org/jolokia/docker/maven/service/BuildService.java
+++ b/src/main/java/org/jolokia/docker/maven/service/BuildService.java
@@ -15,7 +15,7 @@ import org.jolokia.docker.maven.config.ImageConfiguration;
 import org.jolokia.docker.maven.util.Logger;
 import org.jolokia.docker.maven.util.MojoParameters;
 
-public class BuildService {
+public class BuildService implements DockerService {
 
     private final DockerAccess docker;
     private final QueryService queryService;
@@ -84,5 +84,10 @@ public class BuildService {
 
     private boolean oldImageShouldBeRemoved(String oldImageId, String newImageId) {
         return oldImageId != null && !oldImageId.equals(newImageId);
+    }
+
+    @Override
+    public DockerAccess getDockerAccess() {
+        return docker;
     }
 }

--- a/src/main/java/org/jolokia/docker/maven/service/DockerService.java
+++ b/src/main/java/org/jolokia/docker/maven/service/DockerService.java
@@ -1,0 +1,10 @@
+package org.jolokia.docker.maven.service;
+
+import org.jolokia.docker.maven.access.DockerAccess;
+
+/**
+ * Interface to introduce common method getDockerAccess()
+ */
+public interface DockerService {
+    DockerAccess getDockerAccess();
+}

--- a/src/main/java/org/jolokia/docker/maven/service/QueryService.java
+++ b/src/main/java/org/jolokia/docker/maven/service/QueryService.java
@@ -14,7 +14,7 @@ import org.jolokia.docker.maven.util.Logger;
  * Query service for getting image and container information from the docker dameon
  *
  */
-public class QueryService {
+public class QueryService implements DockerService {
 
     // Default limit when listing containers
     private static final int CONTAINER_LIMIT = 100;
@@ -186,5 +186,10 @@ public class QueryService {
     // Check if an image is not loaded but should be pulled
     private boolean pullIfNotPresent(AutoPullMode autoPull, String name) throws DockerAccessException {
         return autoPull.doPullIfNotPresent() && !hasImage(name);
+    }
+
+    @Override
+    public DockerAccess getDockerAccess() {
+        return docker;
     }
 }

--- a/src/main/java/org/jolokia/docker/maven/service/RunService.java
+++ b/src/main/java/org/jolokia/docker/maven/service/RunService.java
@@ -29,7 +29,7 @@ import org.jolokia.docker.maven.util.*;
  * @author roland
  * @since 16/06/15
  */
-public class RunService {
+public class RunService implements DockerService {
 
     // logger delegated from top
     private Logger log;
@@ -351,7 +351,13 @@ public class RunService {
             // Remove the container
             access.removeContainer(containerId, removeVolumes);
         }
-        log.info(descriptor.getDescription() + ": Stop" + (keepContainer ? "" : " and remove") + " container " +
-                 containerId.substring(0, 12));
+        log.info(
+                descriptor.getDescription() + ": Stop" + (keepContainer ? "" : " and remove") + " container " +
+                        containerId.substring(0, 12));
+    }
+
+    @Override
+    public DockerAccess getDockerAccess() {
+        return docker;
     }
 }


### PR DESCRIPTION
I ran across this problem with trying to use the plugin to stop/remove/build/start images on two docker hosts.  ServiceHub was only initialized once and so the second docker configuration used the services that were initialized with the old docker url.  This is an attempt to fix that.