### PR TITLE
Add logconfig option to write logs to specified file

### DIFF
--- a/src/main/java/org/jolokia/docker/maven/AbstractDockerMojo.java
+++ b/src/main/java/org/jolokia/docker/maven/AbstractDockerMojo.java
@@ -290,7 +290,6 @@ public abstract class AbstractDockerMojo extends AbstractMojo implements Context
         LogDispatcher dispatcher = (LogDispatcher) getPluginContext().get(CONTEXT_KEY_LOG_DISPATCHER);
         if (dispatcher == null) {
             dispatcher = new LogDispatcher(docker, useColor);
-            dispatcher.addLogOutputStream(System.out);
             getPluginContext().put(CONTEXT_KEY_LOG_DISPATCHER, dispatcher);
         }
         return dispatcher;
@@ -302,6 +301,7 @@ public abstract class AbstractDockerMojo extends AbstractMojo implements Context
 
         addLogFormat(builder, logConfig);
         addPrefix(builder, logConfig.getPrefix(), imageConfiguration.getAlias(), containerId);
+        addLogFile(builder, logConfig.getFileLocation());
 
         builder.containerId(containerId)
                 .color(logConfig.getColor());
@@ -328,6 +328,11 @@ public abstract class AbstractDockerMojo extends AbstractMojo implements Context
         if (logFormat != null) {
             builder.timeFormatter(logFormat);
         }
+    }
+
+    private void addLogFile(ContainerLogOutputSpec.Builder builder, String logFile) {
+        String file = logFile;
+        builder.file(file);
     }
 
     private LogConfiguration extractLogConfiguration(ImageConfiguration imageConfiguration) {

--- a/src/main/java/org/jolokia/docker/maven/config/LogConfiguration.java
+++ b/src/main/java/org/jolokia/docker/maven/config/LogConfiguration.java
@@ -6,7 +6,7 @@ package org.jolokia.docker.maven.config;
  */
 public class LogConfiguration {
 
-    public static final LogConfiguration DEFAULT = new LogConfiguration(false, null, null, null);
+    public static final LogConfiguration DEFAULT = new LogConfiguration(false, null, null, null, null);
 
     /**
      * @parameter default-value="true"
@@ -28,13 +28,19 @@ public class LogConfiguration {
      */
     private String color;
 
+    /**
+     * @parameter
+     */
+    private String file;
+
     public LogConfiguration() {}
 
-    private LogConfiguration(boolean enabled, String prefix, String color, String date) {
+    private LogConfiguration(boolean enabled, String prefix, String color, String date, String file) {
         this.enabled = enabled;
         this.prefix = prefix;
         this.date = date;
         this.color = color;
+        this.file = file;
     }
 
     public String getPrefix() {
@@ -53,11 +59,15 @@ public class LogConfiguration {
         return enabled;
     }
 
+    public String getFileLocation() {
+        return file;
+    }
+
     // =============================================================================
 
     public static class Builder {
         private boolean enabled = true;
-        private String prefix, timestamp, color;
+        private String prefix, timestamp, color, file;
 
         public Builder enabled(boolean enabled) {
             this.enabled = enabled;
@@ -79,8 +89,13 @@ public class LogConfiguration {
             return this;
         }
 
+        public Builder file(String file) {
+            this.file = file;
+            return this;
+        }
+
         public LogConfiguration build() {
-            return new LogConfiguration(enabled, prefix, color, timestamp);
+            return new LogConfiguration(enabled, prefix, color, timestamp, file);
         }
     }
 }

--- a/src/main/java/org/jolokia/docker/maven/log/ContainerLogOutputSpec.java
+++ b/src/main/java/org/jolokia/docker/maven/log/ContainerLogOutputSpec.java
@@ -28,13 +28,13 @@ import static org.fusesource.jansi.Ansi.ansi;
  */
 public class ContainerLogOutputSpec {
 
-    public static final ContainerLogOutputSpec DEFAULT = new ContainerLogOutputSpec("", YELLOW, null,null);
+    public static final ContainerLogOutputSpec DEFAULT = new ContainerLogOutputSpec("", YELLOW, null,null,null);
 
     private final String containerId;
     private String prefix;
     private Ansi.Color color;
     private DateTimeFormatter timeFormatter;
-
+    private String file;
 
     // Palette used for prefixing the log output
     private final static Ansi.Color COLOR_PALETTE[] = {
@@ -45,11 +45,12 @@ public class ContainerLogOutputSpec {
     //Fill prefix up to this length
     private String FILLER = "                                                                           ";
 
-    private ContainerLogOutputSpec(String prefix, Ansi.Color color, DateTimeFormatter timeFormatter, String containerId) {
+    private ContainerLogOutputSpec(String prefix, Ansi.Color color, DateTimeFormatter timeFormatter, String containerId, String file) {
         this.prefix = prefix;
         this.color = color;
         this.containerId = containerId;
         this.timeFormatter = timeFormatter;
+        this.file = file;
     }
 
     public String getContainerId() {
@@ -59,6 +60,10 @@ public class ContainerLogOutputSpec {
 
     public String getPrompt(boolean withColor,Timestamp timestamp) {
         return formatTimestamp(timestamp,withColor) + formatPrefix(prefix, withColor) + "> ";
+    }
+
+    public String getFile(){
+        return file;
     }
 
     private String formatTimestamp(Timestamp timestamp,boolean withColor) {
@@ -82,6 +87,7 @@ public class ContainerLogOutputSpec {
         private Ansi.Color color;
         private String containerId;
         private DateTimeFormatter timeFormatter;
+        private String file;
 
         public Builder prefix(String prefix) {
             this.prefix = prefix;
@@ -100,6 +106,10 @@ public class ContainerLogOutputSpec {
                             "'. Color must be one YELLOW, CYAN, MAGENTA, GREEN, RED or BLUE");
                 }
             }
+            return this;
+        }
+        public Builder file(String file){
+            this.file = file;
             return this;
         }
 
@@ -137,7 +147,7 @@ public class ContainerLogOutputSpec {
         }
 
         public ContainerLogOutputSpec build() {
-            return new ContainerLogOutputSpec(prefix,color,timeFormatter,containerId);
+            return new ContainerLogOutputSpec(prefix,color,timeFormatter,containerId, file);
         }
 
     }


### PR DESCRIPTION
We are using this plugin at Conductor and would really benefit from this addition. This PR will allow the user to pass the 'file' log configuration option for a given image and specify a location for the logs to be written to. For example:

```
<log>
    <file>${basedir}/app.out</file>
</log>
```

If the file option is empty, it will print to System.out, otherwise it will use FileOutputStream and print to the specified location. 