### PR TITLE
Added support for TCP port wait condition

### DIFF
--- a/doc/manual/docker-start.md
+++ b/doc/manual/docker-start.md
@@ -323,6 +323,9 @@ some condition is met. These conditions can be specified within a
 * **exec** Specifies commands to execute during specified lifecycle of the container. It knows the following sub-elements:
   - **postStart** Command to run after the above wait criteria has been met
   - **preStop** Command to run before the container is stopped.
+* **tcp** specifies TCP port check which periodically polls given tcp ports. It knows the following sub-elements:
+  - **host** is the hostname or the IP address. It defaults to `${docker.host.address}`.
+  - **ports** is a list of TCP ports to check.
   
 As soon as one condition is met the build continues. If you add a
 `<time>` constraint this works more or less as a timeout for other
@@ -345,11 +348,19 @@ Example:
      <postStart>/opt/init_db.sh</postStart>
      <preStop>/opt/notify_end.sh</preStop>
   </exec>
+  <tcp>
+     <host>192.168.99.100</host>
+     <ports>
+        <port>3306</port>
+        <port>9999</port>
+     </ports>
+  </tcp>
 </wait>
 ```` 
 
 This setup will wait for the given URL to be reachable but ten seconds
-at most. Also, when stopping the container after an integration tests, the
+at most. Additionally, it will be waited for the TCP ports 3306 and 9999.
+Also, when stopping the container after an integration tests, the
 build wait for 500 ms before it tries to remove the container (if not `keepContainer`
 or `keepRunning` is used). You can use maven properties in each
 condition, too. In the example, the `${host.port}` property is

--- a/src/main/java/org/jolokia/docker/maven/StartMojo.java
+++ b/src/main/java/org/jolokia/docker/maven/StartMojo.java
@@ -9,6 +9,7 @@ package org.jolokia.docker.maven;
  */
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 import java.util.regex.Pattern;
 
@@ -25,6 +26,7 @@ import org.jolokia.docker.maven.config.LogConfiguration;
 import org.jolokia.docker.maven.config.RunImageConfiguration;
 import org.jolokia.docker.maven.config.WaitConfiguration;
 import org.jolokia.docker.maven.log.LogDispatcher;
+import org.jolokia.docker.maven.model.Container;
 import org.jolokia.docker.maven.service.QueryService;
 import org.jolokia.docker.maven.service.RunService;
 import org.jolokia.docker.maven.util.StartOrderResolver;
@@ -144,6 +146,39 @@ public class StartMojo extends AbstractDockerMojo {
         if (wait.getLog() != null) {
             checkers.add(getLogWaitChecker(wait.getLog(), docker, containerId));
             logOut.add("on log out '" + wait.getLog() + "'");
+        }
+        if (wait.getTcp() != null) {
+            WaitConfiguration.TcpConfiguration tcpConfig = wait.getTcp();
+            try {
+                Container container = docker.inspectContainer(containerId);
+                String host = tcpConfig.getHost();
+                List<Integer> ports = new ArrayList<>();
+
+                if (host == null) {
+                    // Host defaults to ${docker.host.address}.
+                    host = projectProperties.getProperty("docker.host.address");
+                }
+
+                if ("localhost".equals(host)) {
+                    host = container.getIPAddress();
+                    ports = tcpConfig.getPorts();
+                    log.info(String.format("%s: Waiting for ports %s directly on container with IP (%s).", imageConfig.getDescription(), ports, host));
+                } else {
+                    for (int port : tcpConfig.getPorts()) {
+                        Container.PortBinding binding = container.getPortBindings().get(port + "/tcp");
+                        ports.add(binding.getHostPort());
+                    }
+                    log.info(String.format("%s: Waiting for exposed ports %s on remote host (%s), since they are not directly accessible.", imageConfig.getDescription(), ports, host));
+                }
+
+                WaitUtil.TcpPortChecker tcpWaitChecker = new WaitUtil.TcpPortChecker(host, ports);
+                checkers.add(tcpWaitChecker);
+                logOut.add("on tcp port '"+tcpWaitChecker.getPending()+"'");
+
+            } catch (DockerAccessException e) {
+                throw new MojoExecutionException("Unable to access container.", e);
+            }
+
         }
 
         if (checkers.isEmpty()) {

--- a/src/main/java/org/jolokia/docker/maven/config/WaitConfiguration.java
+++ b/src/main/java/org/jolokia/docker/maven/config/WaitConfiguration.java
@@ -1,5 +1,7 @@
 package org.jolokia.docker.maven.config;
 
+import java.util.List;
+
 /**
  * @author roland
  * @since 12.10.14
@@ -30,6 +32,11 @@ public class WaitConfiguration {
     /**
      * @parameter
      */
+    private TcpConfiguration tcp;
+
+    /**
+     * @parameter
+     */
     private String log;
 
     /**
@@ -44,10 +51,11 @@ public class WaitConfiguration {
 
     public WaitConfiguration() {}
 
-    private WaitConfiguration(int time, ExecConfiguration exec, HttpConfiguration http, String log, int shutdown, int kill) {
+    private WaitConfiguration(int time, ExecConfiguration exec, HttpConfiguration http, TcpConfiguration tcp, String log, int shutdown, int kill) {
         this.time = time;
         this.exec = exec;
         this.http = http;
+        this.tcp = tcp;
         this.log = log;
         this.shutdown = shutdown;
         this.kill = kill;
@@ -67,6 +75,10 @@ public class WaitConfiguration {
 
     public HttpConfiguration getHttp() {
         return http;
+    }
+
+    public TcpConfiguration getTcp() {
+        return tcp;
     }
 
     public String getLog() {
@@ -89,6 +101,8 @@ public class WaitConfiguration {
         private String method;
         private String preStop;
         private String postStart;
+        private List<Integer> tcpPorts;
+        private String tcpHost;
 
         public Builder time(int time) {
             this.time = time;
@@ -125,8 +139,20 @@ public class WaitConfiguration {
             return this;
         }
 
+        public Builder tcpPorts(List<Integer> tcpPorts)
+        {
+            this.tcpPorts = tcpPorts;
+            return this;
+        }
+
+        public Builder tcpHost(String tcpHost)
+        {
+            this.tcpHost = tcpHost;
+            return this;
+        }
+
         public WaitConfiguration build() {
-            return new WaitConfiguration(time, new ExecConfiguration(postStart, preStop), new HttpConfiguration(url,method,status), log, shutdown, kill);
+            return new WaitConfiguration(time, new ExecConfiguration(postStart, preStop), new HttpConfiguration(url,method,status), new TcpConfiguration(tcpHost, tcpPorts), log, shutdown, kill);
         }
 
         public Builder preStop(String command) {
@@ -192,4 +218,29 @@ public class WaitConfiguration {
             return status;
         }
     }
+
+    public static class TcpConfiguration
+    {
+        private String host;
+
+        private List<Integer> ports;
+
+        public TcpConfiguration() {};
+
+        private TcpConfiguration(String host, List<Integer> ports) {
+            this.host = host;
+            this.ports = ports;
+        }
+
+        public String getHost()
+        {
+            return host;
+        }
+
+        public List<Integer> getPorts()
+        {
+            return ports;
+        }
+    }
+
 }

--- a/src/main/java/org/jolokia/docker/maven/config/handler/property/ConfigKey.java
+++ b/src/main/java/org/jolokia/docker/maven/config/handler/property/ConfigKey.java
@@ -78,6 +78,8 @@ public enum ConfigKey {
     WAIT_HTTP_STATUS("wait.http.status"),
     WAIT_KILL("wait.kill"),
     WAIT_SHUTDOWN("wait.shutdown"),
+    WAIT_TCP_HOST("wait.tcp.host"),
+    WAIT_TCP_PORT("wait.tcp.port"),
     WATCH_INTERVAL("watch.interval"),
     WATCH_MODE("watch.mode"),
     WATCH_POSTGOAL("watch.postGoal"),

--- a/src/main/java/org/jolokia/docker/maven/config/handler/property/PropertyConfigHandler.java
+++ b/src/main/java/org/jolokia/docker/maven/config/handler/property/PropertyConfigHandler.java
@@ -175,7 +175,9 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
                 .status(withPrefix(prefix, WAIT_HTTP_STATUS, properties))
                 .log(withPrefix(prefix, WAIT_LOG, properties))
                 .kill(asInt(withPrefix(prefix, WAIT_KILL, properties)))
-                .shutdown(asInt(withPrefix(prefix,WAIT_SHUTDOWN,properties)))
+                .shutdown(asInt(withPrefix(prefix, WAIT_SHUTDOWN, properties)))
+                .tcpHost(withPrefix(prefix, WAIT_TCP_HOST, properties))
+                .tcpPorts(asIntList(listWithPrefix(prefix, WAIT_TCP_PORT, properties)))
                 .build();
     }
     
@@ -196,6 +198,20 @@ public class PropertyConfigHandler implements ExternalConfigHandler {
   
     private int asInt(String s) {
         return s != null ? Integer.parseInt(s) : 0;
+    }
+
+    private List<Integer> asIntList(List<String> strings) {
+        if (strings == null) {
+            return null;
+        }
+
+        List<Integer> ints = new ArrayList<>();
+        for (String s : strings) {
+            ints.add(asInt(s));
+        }
+
+        return ints;
+
     }
 
     private List<String> listWithPrefix(String prefix, ConfigKey key, Properties properties) {

--- a/src/main/java/org/jolokia/docker/maven/model/Container.java
+++ b/src/main/java/org/jolokia/docker/maven/model/Container.java
@@ -37,6 +37,8 @@ public interface Container {
 
     boolean isRunning();
 
+    String getIPAddress();
+
     class PortBinding {
         private final String hostIp;
         private final Integer hostPort;

--- a/src/main/java/org/jolokia/docker/maven/model/ContainerDetails.java
+++ b/src/main/java/org/jolokia/docker/maven/model/ContainerDetails.java
@@ -22,6 +22,7 @@ public class ContainerDetails implements Container {
     static String ID = "Id";
     static String IMAGE = "Image";
     static String PORTS = "Ports";
+    static String IP = "IPAddress";
     static String SLASH = "/";
 
     private static final String RUNNING = "Running";
@@ -59,6 +60,18 @@ public class ContainerDetails implements Container {
             name = name.substring(1);
         }
         return name;
+    }
+
+    @Override
+    public String getIPAddress() {
+        if (json.has(NETWORK_SETTINGS) && !json.isNull(NETWORK_SETTINGS)) {
+            JSONObject networkSettings = json.getJSONObject(NETWORK_SETTINGS);
+            if (!networkSettings.isNull(PORTS)) {
+                return networkSettings.getString(IP);
+            }
+        }
+        return null;
+
     }
 
     @Override

--- a/src/main/java/org/jolokia/docker/maven/model/ContainerDetails.java
+++ b/src/main/java/org/jolokia/docker/maven/model/ContainerDetails.java
@@ -8,8 +8,6 @@ import javax.xml.bind.DatatypeConverter;
 
 import org.json.JSONObject;
 
-import edu.emory.mathcs.backport.java.util.Collections;
-
 public class ContainerDetails implements Container {
 
     static final String CONFIG = "Config";
@@ -66,7 +64,7 @@ public class ContainerDetails implements Container {
     public String getIPAddress() {
         if (json.has(NETWORK_SETTINGS) && !json.isNull(NETWORK_SETTINGS)) {
             JSONObject networkSettings = json.getJSONObject(NETWORK_SETTINGS);
-            if (!networkSettings.isNull(PORTS)) {
+            if (!networkSettings.isNull(IP)) {
                 return networkSettings.getString(IP);
             }
         }
@@ -83,7 +81,7 @@ public class ContainerDetails implements Container {
             }
         }
 
-        return Collections.emptyMap();
+        return new HashMap<>();
     }
 
     @Override

--- a/src/main/java/org/jolokia/docker/maven/model/ContainersListElement.java
+++ b/src/main/java/org/jolokia/docker/maven/model/ContainersListElement.java
@@ -76,6 +76,12 @@ public class ContainersListElement implements Container {
     }
 
     @Override
+    public String getIPAddress() {
+        // IP address is not provided by container list action.
+        return null;
+    }
+
+    @Override
     public boolean isRunning() {
         String status = json.getString(STATUS);
         return status.toLowerCase().contains(UP);

--- a/src/main/java/org/jolokia/docker/maven/util/WaitUtil.java
+++ b/src/main/java/org/jolokia/docker/maven/util/WaitUtil.java
@@ -18,6 +18,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
 import org.apache.http.impl.client.HttpClientBuilder;
 
+
 /**
  * @author roland
  * @since 18.10.14
@@ -102,7 +103,7 @@ public class WaitUtil {
      */
     public static class HttpPingChecker implements WaitChecker {
 
-        private int statusMin,statusMax;
+        private int statusMin, statusMax;
         private String url;
         private String method;
 
@@ -136,7 +137,7 @@ public class WaitUtil {
         }
 
         public HttpPingChecker(String waitUrl) {
-            this(waitUrl,null,null);
+            this(waitUrl, null, null);
         }
 
         @Override
@@ -151,10 +152,10 @@ public class WaitUtil {
         private boolean ping() throws IOException {
             RequestConfig requestConfig =
                     RequestConfig.custom()
-                                 .setSocketTimeout(HTTP_PING_TIMEOUT)
-                                 .setConnectTimeout(HTTP_PING_TIMEOUT)
-                                 .setConnectionRequestTimeout(HTTP_PING_TIMEOUT)
-                                 .build();
+                            .setSocketTimeout(HTTP_PING_TIMEOUT)
+                            .setConnectTimeout(HTTP_PING_TIMEOUT)
+                            .setConnectionRequestTimeout(HTTP_PING_TIMEOUT)
+                            .build();
             CloseableHttpClient httpClient = HttpClientBuilder.create()
                     .setDefaultRequestConfig(requestConfig)
                     .setRetryHandler(new DefaultHttpRequestRetryHandler(HTTP_CLIENT_RETRIES, false))
@@ -183,7 +184,6 @@ public class WaitUtil {
 
     /**
      * Check whether a given TCP port is available
-     *
      */
     public static class TcpPortChecker implements WaitChecker {
         private static final int TCP_TIMEOUT = 2000;
@@ -196,7 +196,7 @@ public class WaitUtil {
             this.ports = ports;
 
             this.pending = new ArrayList<>();
-            for (int port : ports ) {
+            for (int port : ports) {
                 this.pending.add(new InetSocketAddress(host, port));
             }
 
@@ -230,21 +230,20 @@ public class WaitUtil {
                 }
 
             }
-
             return pending.isEmpty();
-
         }
 
         @Override
         public void cleanUp() {
 
         }
-    };
+    }
 
     // ====================================================================================================
 
     public interface WaitChecker {
         boolean check();
+
         void cleanUp();
     }
 

--- a/src/test/java/org/jolokia/docker/maven/util/WaitUtilTest.java
+++ b/src/test/java/org/jolokia/docker/maven/util/WaitUtilTest.java
@@ -2,6 +2,7 @@ package org.jolokia.docker.maven.util;
 
 import java.io.IOException;
 import java.net.*;
+import java.util.Arrays;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeoutException;
 
@@ -58,6 +59,13 @@ public class WaitUtilTest {
         } finally {
             serverMethodToAssert = "HEAD";
         }
+    }
+
+    @Test
+    public void tcpSuccess() throws TimeoutException {
+        WaitUtil.TcpPortChecker checker = new WaitUtil.TcpPortChecker("localhost", Arrays.asList(port));
+        long waited = WaitUtil.wait(700,checker);
+        assertTrue("Waited less than 700ms: " + waited, waited < 700);
     }
 
     @Test

--- a/src/test/java/org/jolokia/docker/maven/util/WaitUtilTest.java
+++ b/src/test/java/org/jolokia/docker/maven/util/WaitUtilTest.java
@@ -3,6 +3,7 @@ package org.jolokia.docker.maven.util;
 import java.io.IOException;
 import java.net.*;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeoutException;
 
@@ -63,7 +64,7 @@ public class WaitUtilTest {
 
     @Test
     public void tcpSuccess() throws TimeoutException {
-        WaitUtil.TcpPortChecker checker = new WaitUtil.TcpPortChecker("localhost", Arrays.asList(port));
+        WaitUtil.TcpPortChecker checker = new WaitUtil.TcpPortChecker("localhost", Collections.singletonList(port));
         long waited = WaitUtil.wait(700,checker);
         assertTrue("Waited less than 700ms: " + waited, waited < 700);
     }


### PR DESCRIPTION
Example:

```xml
<wait>
   <time>60000</time>
   <tcp>
      <ports>
         <port>3306</port>
         <port>9999</port>
      </ports>
</wait>
```

This will setup a TCP port checker for ports 3306 and 9999. The test will time out after 60 seconds and the poll interval is hard coded, just like the HTTP wait condition.

This configuration differs from the proposed one in the issue #304:

* I remove the `<interval>` property, because this is already hardcoded with `org.jolokia.docker.maven.util.WaitUtil#WAIT_RETRY_WAIT` in `org.jolokia.docker.maven.util.WaitUtil#wait()`.
* Added support for multiple port checks.
