### PR TITLE
resolves issue-87

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 [![Flattr](http://api.flattr.com/button/flattr-badge-large.png)](http://flattr.com/thing/73919/Jolokia-JMX-on-Capsaicin)
 
 This is a Maven plugin for managing Docker images and containers for your builds.
-The current version is **0.13.6** and works with Maven 3.2.1 and Docker 1.6.0 or later.
+The current version is **0.14.0** and works with Maven 3.2.1 and Docker 1.6.0 or later.
 
-The current Docker API version used is `v1.17` (which is the minimal required API version). If you want to use the 
+The current Docker API version used is `v1.18` (which is the minimal required API version). If you want to use the 
 copy mode for `docker:watch` you need `v1.20` or greater (Docker 1.8.1). See the **[User Manual](https://rhuss.github.io/docker-maven-plugin)** 
 for details on how to override this value for new
 versions of Docker. For older Docker version please use **0.12.0** with support for `v1.15` 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+* **0.14.0**
+  - `docker:stop` no longer acts like a sledgehammer
+    ([#87](https://github.com/rhuss/docker-maven-plugin/issues/87))
+
 * **0.13.6**
   - Don't use user from image when pulling base images ([#147](https://github.com/rhuss/docker-maven-plugin/issues/147))
   - Add a new assembly descriptor reference  `hawt-app` for using asseblies created by 

--- a/doc/manual/docker-stop.md
+++ b/doc/manual/docker-stop.md
@@ -1,17 +1,26 @@
 ### docker:stop
 
-Stops and removes a docker container. This goals starts every
-container started with `<docker:stop>` either during the same build
+Stops and removes a docker container. This goals stops every
+container started with `<docker:start>` either during the same build
 (e.g. when bound to lifecycle phases when doing integration tests) or
 for containers created by a previous call to `<docker:start>`
 
-If called within the same build run it will exactly stop and destroy
-all containers started by this plugin. If called in a separate run it
-will stop (and destroy) all containers which were created from images
-which are configured for this goal. This might be dangerous, but of
-course you can always stop your containers with the Docker CLI, too.
+If called within the same build run, only the containers that were 
+explicitly started during the run will be stopped. Existing containers
+started using `docker:start` for the project will not be affected.
 
-For tuning what should happen when stopping there are two global
+If called as a separate invocation, the plugin will stop and remove any
+container it finds whose image is defined in the project's configuration.
+Any existing containers found running whose image name matches but was not 
+started by the plugin will not be affected.
+
+It should be noted that any containers created prior to version `0.14.0` of the
+plugin may not be stopped correctly by the plugin b/c the label needed to tie
+the container to the project may not exist. Should this happen, you will need to
+use the Docker CLI to clean up the containers and/or use the `docker.sledgehammer`
+option listed below. 
+
+For tuning what should happen when stopping there are three global
 parameters which are typically used as system properties:
 
 * **keepContainer** (`docker.keepContainer`) If given will not destroy
@@ -25,6 +34,10 @@ parameters which are typically used as system properties:
 * **removeVolumes** (`docker.removeVolumes`) If given will remove any
   volumes associated to the container as well. This option will be ignored
   if either `keepContainer` or `keepRunning` are true.
+* **sledgehammer** (`docker.sledgehammer`) Stops and removes any container that
+  matches an image defined in the current project's configuration. This was the
+  default behavior of the plugin prior to [issue #87](https://github.com/rhuss/docker-maven-plugin/issues/87)
+  being resolved.
 
 Example: 
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.jolokia</groupId>
   <artifactId>docker-maven-plugin</artifactId>
-  <version>0.13.7-SNAPSHOT</version>
+  <version>0.14.0-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>maven-docker-plugin</name>

--- a/src/main/java/org/jolokia/docker/maven/AbstractDockerMojo.java
+++ b/src/main/java/org/jolokia/docker/maven/AbstractDockerMojo.java
@@ -41,7 +41,7 @@ public abstract class AbstractDockerMojo extends AbstractMojo implements Context
     // docker installations.
     public static final String DOCKER_HTTPS_PORT = "2376";
 
-    public static final String API_VERSION = "v1.17";
+    public static final String API_VERSION = "v1.18";
 
     // Current maven project
     /** @parameter default-value="${project}" */

--- a/src/main/java/org/jolokia/docker/maven/AbstractDockerMojo.java
+++ b/src/main/java/org/jolokia/docker/maven/AbstractDockerMojo.java
@@ -276,6 +276,12 @@ public abstract class AbstractDockerMojo extends AbstractMojo implements Context
 
     // =================================================================================
 
+    protected PomLabel getPomLabel() {
+        // Label used for this run
+        return new PomLabel(project.getGroupId(),project.getArtifactId(),project.getVersion());
+    }
+
+
     protected AuthConfig prepareAuthConfig(String image, String configuredRegistry, boolean useUserFromImage) throws MojoExecutionException {
         ImageName name = new ImageName(image);
         String user = useUserFromImage ? name.getUser() : null;

--- a/src/main/java/org/jolokia/docker/maven/AbstractDockerMojo.java
+++ b/src/main/java/org/jolokia/docker/maven/AbstractDockerMojo.java
@@ -35,7 +35,7 @@ public abstract class AbstractDockerMojo extends AbstractMojo implements Context
     public static final String CONTEXT_KEY_START_CALLED = "CONTEXT_KEY_DOCKER_START_CALLED";
 
     // Key holding the log dispatcher
-    public static final Object CONTEXT_KEY_LOG_DISPATCHER = "CONTEXT_KEY_DOCKER_LOG_DISPATCHER";
+    public static final String CONTEXT_KEY_LOG_DISPATCHER = "CONTEXT_KEY_DOCKER_LOG_DISPATCHER";
 
     // Standard HTTPS port (IANA registered). The other 2375 with plain HTTP is used only in older
     // docker installations.

--- a/src/main/java/org/jolokia/docker/maven/StartMojo.java
+++ b/src/main/java/org/jolokia/docker/maven/StartMojo.java
@@ -58,9 +58,6 @@ public class StartMojo extends AbstractDockerMojo {
         RunService runService = serviceHub.getRunService();
 
         LogDispatcher dispatcher = getLogDispatcher(dockerAccess);
-        
-        ContainerLabel label = new ContainerLabel(project.getGroupId(),project.getArtifactId(),project.getVersion());
-        
 
         PortMapping.PropertyWriteHelper portMappingPropertyWriteHelper = new PortMapping.PropertyWriteHelper(portPropertyFile);
         
@@ -79,7 +76,7 @@ public class StartMojo extends AbstractDockerMojo {
                 RunImageConfiguration runConfig = imageConfig.getRunConfiguration();
                 PortMapping portMapping = runService.getPortMapping(runConfig, projProperties);
 
-                String containerId = runService.createAndStartContainer(imageConfig, portMapping, projProperties);
+                String containerId = runService.createAndStartContainer(imageConfig, portMapping, getPomLabel(), projProperties);
 
                 if (showLogs(imageConfig)) {
                     dispatcher.trackContainerLog(containerId,

--- a/src/main/java/org/jolokia/docker/maven/StartMojo.java
+++ b/src/main/java/org/jolokia/docker/maven/StartMojo.java
@@ -7,6 +7,7 @@ package org.jolokia.docker.maven;
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Properties;
@@ -15,21 +16,14 @@ import java.util.regex.Pattern;
 import org.apache.commons.lang3.text.StrSubstitutor;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.codehaus.plexus.util.StringUtils;
-import org.jolokia.docker.maven.access.DockerAccess;
-import org.jolokia.docker.maven.access.DockerAccessException;
-import org.jolokia.docker.maven.access.PortMapping;
+import org.jolokia.docker.maven.access.*;
 import org.jolokia.docker.maven.access.log.LogCallback;
 import org.jolokia.docker.maven.access.log.LogGetHandle;
-import org.jolokia.docker.maven.config.ImageConfiguration;
-import org.jolokia.docker.maven.config.LogConfiguration;
-import org.jolokia.docker.maven.config.RunImageConfiguration;
-import org.jolokia.docker.maven.config.WaitConfiguration;
+import org.jolokia.docker.maven.config.*;
 import org.jolokia.docker.maven.log.LogDispatcher;
 import org.jolokia.docker.maven.service.QueryService;
 import org.jolokia.docker.maven.service.RunService;
-import org.jolokia.docker.maven.util.StartOrderResolver;
-import org.jolokia.docker.maven.util.Timestamp;
-import org.jolokia.docker.maven.util.WaitUtil;
+import org.jolokia.docker.maven.util.*;
 
 
 /**
@@ -64,6 +58,9 @@ public class StartMojo extends AbstractDockerMojo {
         RunService runService = serviceHub.getRunService();
 
         LogDispatcher dispatcher = getLogDispatcher(dockerAccess);
+        
+        ContainerLabel label = new ContainerLabel(project.getGroupId(),project.getArtifactId(),project.getVersion());
+        
 
         PortMapping.PropertyWriteHelper portMappingPropertyWriteHelper = new PortMapping.PropertyWriteHelper(portPropertyFile);
         

--- a/src/main/java/org/jolokia/docker/maven/StopMojo.java
+++ b/src/main/java/org/jolokia/docker/maven/StopMojo.java
@@ -1,5 +1,7 @@
 package org.jolokia.docker.maven;
 
+import java.util.Map;
+
 import org.apache.maven.plugin.MojoExecutionException;
 import org.jolokia.docker.maven.access.DockerAccess;
 import org.jolokia.docker.maven.access.DockerAccessException;
@@ -8,6 +10,7 @@ import org.jolokia.docker.maven.log.LogDispatcher;
 import org.jolokia.docker.maven.model.Container;
 import org.jolokia.docker.maven.service.QueryService;
 import org.jolokia.docker.maven.service.RunService;
+import org.jolokia.docker.maven.util.PomLabel;
 
 /**
  * Mojo for stopping containers. If called together with <code>docker:start</code> (i.e.
@@ -35,28 +38,57 @@ public class StopMojo extends AbstractDockerMojo {
 
     @Override
     protected void executeInternal(DockerAccess access) throws MojoExecutionException, DockerAccessException {
-        Boolean startCalled = (Boolean) getPluginContext().get(CONTEXT_KEY_START_CALLED);
-
         QueryService queryService = serviceHub.getQueryService();
         RunService runService = serviceHub.getRunService();
-
         
         if (!keepRunning) {
-            if (startCalled == null || !startCalled) {
-                // Called directly ....
-                for (ImageConfiguration image : getImages()) {
-                    String imageName = image.getName();
-                    for (Container container : queryService.getContainersForImage(imageName)) {
-                        runService.stopContainer(container.getId(), image, keepContainer, removeVolumes);
-                    }
-                }
-            } else {
+            if (invokedViaDockerStart()) {
                 runService.stopStartedContainers(keepContainer, removeVolumes);
+            } else {
+                stopAndRemoveContainers(queryService, runService);
             }
         }
 
         // Switch off all logging
         LogDispatcher dispatcher = getLogDispatcher(access);
         dispatcher.untrackAllContainerLogs();
+    }
+    
+    private boolean invokedViaDockerStart() {
+        Boolean startCalled = (Boolean) getPluginContext().get(CONTEXT_KEY_START_CALLED);
+        return (startCalled != null && startCalled == true);
+    }
+    
+    private boolean isSledgeHammerEnabled() {
+        return Boolean.valueOf(System.getProperty("docker.sledgehammer", Boolean.FALSE.toString()));
+    }
+    
+    private boolean shouldStopContainer(Container container, PomLabel pomLabel) {
+        boolean stopContainer = true;
+
+        if (!isSledgeHammerEnabled()) {
+            String key = pomLabel.getKey();        
+            Map<String, String> labels = container.getLabels();
+
+            if (labels.containsKey(key)) {
+                stopContainer = pomLabel.matches(new PomLabel(labels.get(key)), false);
+            }
+        }
+
+        return stopContainer;
+    }
+    
+    private void stopAndRemoveContainers(QueryService queryService, RunService runService) throws DockerAccessException { 
+        PomLabel pomLabel = getPomLabel();
+
+        for (ImageConfiguration image : getImages()) {
+            String imageName = image.getName();
+        
+            for (Container container : queryService.getContainersForImage(imageName)) {
+                if (shouldStopContainer(container, pomLabel)) {
+                    runService.stopContainer(container.getId(), image, keepContainer, removeVolumes);
+                }
+            }
+        }
     }
 }

--- a/src/main/java/org/jolokia/docker/maven/WatchMojo.java
+++ b/src/main/java/org/jolokia/docker/maven/WatchMojo.java
@@ -240,7 +240,7 @@ public class WatchMojo extends AbstractBuildSupportMojo {
         runService.stopContainer(id, false, false);
 
         // Start new one
-        watcher.setContainerId(runService.createAndStartContainer(imageConfig, mappedPorts, project.getProperties()));
+        watcher.setContainerId(runService.createAndStartContainer(imageConfig, mappedPorts, getPomLabel(), project.getProperties()));
     }
 
     private String getPreStopCommand(ImageConfiguration imageConfig) {

--- a/src/main/java/org/jolokia/docker/maven/access/DockerAccess.java
+++ b/src/main/java/org/jolokia/docker/maven/access/DockerAccess.java
@@ -2,12 +2,15 @@ package org.jolokia.docker.maven.access;
 
 import java.io.File;
 import java.util.List;
+import java.util.Map;
 
 import org.jolokia.docker.maven.access.log.LogCallback;
 import org.jolokia.docker.maven.access.log.LogGetHandle;
 import org.jolokia.docker.maven.config.Arguments;
 import org.jolokia.docker.maven.log.LogOutputSpec;
 import org.jolokia.docker.maven.model.*;
+import org.jolokia.docker.maven.model.Container;
+import org.jolokia.docker.maven.util.ContainerLabel;
 
 /**
  * Access to the <a href="http://docs.docker.io/en/latest/reference/api/docker_remote_api/">Docker API</a> which
@@ -98,17 +101,6 @@ public interface DockerAccess {
      * @throws DockerAccessException if the container could not be stopped.
      */
     void stopContainer(String containerId, int killWait) throws DockerAccessException;
-
-    /**
-     * Copy an archive (must be a tar) into a running container
-     *
-     * @param containerId container to copy into
-     * @param archive local archive to copy into
-     * @param targetPath target path to use
-     * @throws DockerAccessException
-     */
-    void copyArchive(String containerId, File archive, String targetPath)
-            throws DockerAccessException;
 
     /**
      * Get logs for a container up to now synchronously.

--- a/src/main/java/org/jolokia/docker/maven/access/DockerAccess.java
+++ b/src/main/java/org/jolokia/docker/maven/access/DockerAccess.java
@@ -111,6 +111,19 @@ public interface DockerAccess {
      */
     List<String> getContainersWithLabel(PomLabel label) throws DockerAccessException;
 
+    /** Copy an archive (must be a tar) into a running container
+     * Get all containers matching a certain label. This might not be a cheap operation especially if many containers
+     * are running. Use with care.
+     *
+     * @param containerId container to copy into
+     * @param archive local archive to copy into
+     * @param targetPath target path to use
+     * @throws DockerAccessException
+     */
+    void copyArchive(String containerId, File archive, String targetPath)
+            throws DockerAccessException;
+
+     /**
     /**
      * Get logs for a container up to now synchronously.
      *

--- a/src/main/java/org/jolokia/docker/maven/access/DockerAccess.java
+++ b/src/main/java/org/jolokia/docker/maven/access/DockerAccess.java
@@ -2,7 +2,6 @@ package org.jolokia.docker.maven.access;
 
 import java.io.File;
 import java.util.List;
-import java.util.Map;
 
 import org.jolokia.docker.maven.access.log.LogCallback;
 import org.jolokia.docker.maven.access.log.LogGetHandle;
@@ -10,7 +9,7 @@ import org.jolokia.docker.maven.config.Arguments;
 import org.jolokia.docker.maven.log.LogOutputSpec;
 import org.jolokia.docker.maven.model.*;
 import org.jolokia.docker.maven.model.Container;
-import org.jolokia.docker.maven.util.ContainerLabel;
+import org.jolokia.docker.maven.util.PomLabel;
 
 /**
  * Access to the <a href="http://docs.docker.io/en/latest/reference/api/docker_remote_api/">Docker API</a> which
@@ -101,6 +100,16 @@ public interface DockerAccess {
      * @throws DockerAccessException if the container could not be stopped.
      */
     void stopContainer(String containerId, int killWait) throws DockerAccessException;
+
+    /**
+     * Get all containers matching a certain label. This might not be a cheap operation especially if many containers
+     * are running. Use with care.
+     *
+     * @param label label which the container must match
+     * @return list of container names matching the label.
+     * @see PomLabel#matches(PomLabel)
+     */
+    List<String> getContainersWithLabel(PomLabel label) throws DockerAccessException;
 
     /**
      * Get logs for a container up to now synchronously.

--- a/src/main/java/org/jolokia/docker/maven/access/hc/DockerAccessWithHcClient.java
+++ b/src/main/java/org/jolokia/docker/maven/access/hc/DockerAccessWithHcClient.java
@@ -1,15 +1,19 @@
 package org.jolokia.docker.maven.access.hc;
 
+import java.io.*;
+import java.net.URI;
+import java.util.*;
+
 import org.apache.http.HttpResponse;
 import org.apache.http.client.ResponseHandler;
 import org.jolokia.docker.maven.access.*;
 import org.jolokia.docker.maven.access.chunked.*;
 import org.jolokia.docker.maven.access.hc.http.HttpClientBuilder;
 import org.jolokia.docker.maven.access.hc.unix.UnixSocketClientBuilder;
-import org.jolokia.docker.maven.access.log.LogCallback;
-import org.jolokia.docker.maven.access.log.LogGetHandle;
-import org.jolokia.docker.maven.access.log.LogRequestor;
+import org.jolokia.docker.maven.access.log.*;
 import org.jolokia.docker.maven.config.Arguments;
+import org.jolokia.docker.maven.model.*;
+import org.jolokia.docker.maven.util.*;
 import org.jolokia.docker.maven.log.LogOutputSpec;
 import org.jolokia.docker.maven.log.DefaultLogCallback;
 import org.jolokia.docker.maven.model.Container;
@@ -74,7 +78,7 @@ public class DockerAccessWithHcClient implements DockerAccess {
         }
         if (uri.getScheme().equalsIgnoreCase("unix")) {
             this.delegate =
-                    new ApacheHttpClientDelegate(new UnixSocketClientBuilder().build(uri.getPath(),maxConnections));
+                    new ApacheHttpClientDelegate(new UnixSocketClientBuilder().build(uri.getPath(), maxConnections));
             this.urlBuilder = new UrlBuilder(DUMMY_BASE_URL, apiVersion);
         } else {
             HttpClientBuilder builder = new HttpClientBuilder();
@@ -145,7 +149,7 @@ public class DockerAccessWithHcClient implements DockerAccess {
         } catch (IOException e) {
             log.error(e.getMessage());
             throw new DockerAccessException("Unable to exec [%s] on container [%s]", request.toString(),
-                    containerId);
+                                            containerId);
         }
 
     }
@@ -192,6 +196,12 @@ public class DockerAccessWithHcClient implements DockerAccess {
             log.error(e.getMessage());
             throw new DockerAccessException("Unable to stop container id [%s]", containerId);
         }
+    }
+
+    @Override
+    public List<String> getContainersWithLabel(PomLabel label) throws DockerAccessException {
+        // TODO: Implementation
+        return null;
     }
 
     @Override

--- a/src/main/java/org/jolokia/docker/maven/model/Container.java
+++ b/src/main/java/org/jolokia/docker/maven/model/Container.java
@@ -24,13 +24,14 @@ import java.util.Map;
  */
 public interface Container {
 
-
     long getCreated();
 
     String getId();
 
     String getImage();
 
+    Map<String, String> getLabels();
+    
     String getName();
 
     Map<String, PortBinding> getPortBindings();

--- a/src/main/java/org/jolokia/docker/maven/model/ContainerDetails.java
+++ b/src/main/java/org/jolokia/docker/maven/model/ContainerDetails.java
@@ -1,28 +1,26 @@
 package org.jolokia.docker.maven.model;
 
-import java.util.Calendar;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 import javax.xml.bind.DatatypeConverter;
 
 import org.json.JSONObject;
 
-import edu.emory.mathcs.backport.java.util.Collections;
 
 public class ContainerDetails implements Container {
 
     static final String CONFIG = "Config";
+    static final String CREATED = "Created";
     static final String HOST_IP = "HostIp";
     static final String HOST_PORT = "HostPort";
+    static final String ID = "Id";
+    static final String IMAGE = "Image";
+    static final String LABELS = "Labels";
     static final String NAME = "Name";
     static final String NETWORK_SETTINGS = "NetworkSettings";
+    static final String PORTS = "Ports";
+    static final String SLASH = "/";
     static final String STATE = "State";
-    static String CREATED = "Created";
-    static String ID = "Id";
-    static String IMAGE = "Image";
-    static String PORTS = "Ports";
-    static String SLASH = "/";
 
     private static final String RUNNING = "Running";
     
@@ -49,6 +47,15 @@ public class ContainerDetails implements Container {
     public String getImage() {
         // ID: json.getString("Image");
         return json.getJSONObject(CONFIG).getString(IMAGE);
+    }
+
+    @Override
+    public Map<String, String> getLabels() {
+        if (!json.getJSONObject(CONFIG).has(LABELS)) {
+            return Collections.emptyMap();
+        }
+         
+         return mapLabels(json.getJSONObject(CONFIG).getJSONObject(LABELS));
     }
 
     @Override
@@ -110,4 +117,17 @@ public class ContainerDetails implements Container {
 
         return portBindings;
     }
+    
+    private Map<String, String> mapLabels(JSONObject labels) {
+        int length = labels.length();
+        Map<String, String> mapped = new HashMap<>(length);
+        
+        Iterator<String> iterator = labels.keys();
+        while (iterator.hasNext()) {
+            String key = iterator.next();
+            mapped.put(key, labels.get(key).toString());
+        }
+                
+        return mapped;
+    }    
 }

--- a/src/main/java/org/jolokia/docker/maven/model/ContainersListElement.java
+++ b/src/main/java/org/jolokia/docker/maven/model/ContainersListElement.java
@@ -1,28 +1,26 @@
 package org.jolokia.docker.maven.model;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
 
 public class ContainersListElement implements Container {
         
+    static final String CREATED = "Created";
+    static final String ID = "Id";
+    static final String IMAGE = "Image";
     static final String IP = "IP";
+    static final String LABELS = "Labels";
+    static final String PORTS = "Ports";
     static final String PUBLIC_PORT = "PublicPort";
     static final String STATUS = "Status";
     static final String TYPE = "Type";
 
     private static final String NAMES = "Names";
     private static final String PRIVATE_PORT = "PrivatePort";
+    private static final String SLASH = "/";
     private static final String UP = "up";
-
-    static String CREATED = "Created";
-    static String ID = "Id";
-    static String IMAGE = "Image";
-    static String PORTS = "Ports";
-    private static String SLASH = "/";
 
     private final JSONObject json;
 
@@ -44,6 +42,15 @@ public class ContainersListElement implements Container {
     @Override
     public String getImage() {
         return json.getString(IMAGE);
+    }
+
+    @Override
+    public Map<String, String> getLabels() {
+       if (json.isNull(LABELS)) {
+           return Collections.emptyMap();
+       }
+        
+        return mapLabels(json.getJSONObject(LABELS));
     }
 
     @Override
@@ -95,6 +102,19 @@ public class ContainersListElement implements Container {
         return String.format("%s/%s", object.getInt(PRIVATE_PORT), object.getString(TYPE));
     }
 
+    private Map<String, String> mapLabels(JSONObject labels) {
+        int length = labels.length();
+        Map<String, String> mapped = new HashMap<>(length);
+        
+        Iterator<String> iterator = labels.keys();
+        while (iterator.hasNext()) {
+            String key = iterator.next();
+            mapped.put(key, labels.get(key).toString());
+        }
+                
+        return mapped;
+    }
+    
     private Map<String, PortBinding> mapPortBindings(JSONArray ports) {
         int length = ports.length();
         Map<String, PortBinding> portBindings = new HashMap<>(length);

--- a/src/main/java/org/jolokia/docker/maven/service/RunService.java
+++ b/src/main/java/org/jolokia/docker/maven/service/RunService.java
@@ -87,11 +87,12 @@ public class RunService {
      */
     public String createAndStartContainer(ImageConfiguration imageConfig,
                                           PortMapping mappedPorts,
+                                          PomLabel pomLabel,
                                           Properties mavenProps) throws DockerAccessException {
         RunImageConfiguration runConfig = imageConfig.getRunConfiguration();
         String imageName = imageConfig.getName();
         String containerName = calculateContainerName(imageConfig.getAlias(), runConfig.getNamingStrategy());
-        ContainerCreateConfig config = createContainerConfig(imageName, runConfig, mappedPorts, mavenProps);
+        ContainerCreateConfig config = createContainerConfig(imageName, runConfig, mappedPorts, pomLabel, mavenProps);
 
         String id = docker.createContainer(config, containerName);
         startContainer(imageConfig, id);
@@ -223,7 +224,7 @@ public class RunService {
 
     // visible for testing
     ContainerCreateConfig createContainerConfig(String imageName, RunImageConfiguration runConfig, PortMapping mappedPorts,
-                                                Properties mavenProps)
+                                                PomLabel pomLabel, Properties mavenProps)
             throws DockerAccessException {
         try {
             ContainerCreateConfig config = new ContainerCreateConfig(imageName)
@@ -236,7 +237,7 @@ public class RunService {
                     .entrypoint(runConfig.getEntrypoint())
                     .exposedPorts(mappedPorts.getContainerPorts())
                     .environment(runConfig.getEnvPropertyFile(), runConfig.getEnv(), mavenProps)
-                    .labels(runConfig.getLabels())
+                    .labels(mergeLabels(runConfig.getLabels(), pomLabel))
                     .command(runConfig.getCmd())
                     .hostConfig(createContainerHostConfig(runConfig, mappedPorts));
             VolumeConfiguration volumeConfig = runConfig.getVolumeConfiguration();
@@ -247,6 +248,17 @@ public class RunService {
         } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException(String.format("Failed to create contained configuration for [%s]", imageName), e);
         }
+    }
+
+    private Map<String, String> mergeLabels(Map<String, String> labels, PomLabel runIdLabel) {
+        Map<String,String> ret = new HashMap<>();
+        if (labels != null) {
+            ret.putAll(labels);
+        }
+        if (runIdLabel != null) {
+            ret.put(runIdLabel.getKey(), runIdLabel.getValue());
+        }
+        return ret;
     }
 
     ContainerHostConfig createContainerHostConfig(RunImageConfiguration runConfig, PortMapping mappedPorts)

--- a/src/main/java/org/jolokia/docker/maven/util/ContainerLabel.java
+++ b/src/main/java/org/jolokia/docker/maven/util/ContainerLabel.java
@@ -1,0 +1,102 @@
+package org.jolokia.docker.maven.util;/*
+ * 
+ * Copyright 2014 Roland Huss
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.util.UUID;
+
+/**
+ * Label used to mark a container belonging to a certain build.
+ *
+ * @author roland
+ * @since 31/03/15
+ */
+public class ContainerLabel {
+
+    private String mavenCoordinates;
+    private String runId;
+
+
+    // Environment variable used to label containers
+    public static final String CONTAINER_LABEL_NAME = "docker.maven.plugin.container";
+
+    /**
+     * Construct from a given label
+     *
+     * @param label label as stored with the container
+     */
+    public ContainerLabel(String label) {
+        String[] parts = label.split(":");
+        if (parts.length != 4 && parts.length != 3) {
+            throw new IllegalArgumentException("Label '" + label +
+                                               "' has not the format <group>:<artifact>:<version>[:<runId>]");
+        }
+        mavenCoordinates = parts[0] + ":" + parts[1] + ":" + parts[2];
+        runId = parts.length == 4 ? parts[3] : null;
+    }
+
+    /**
+     * Construct from maven coordinates. A random run-ID is created automatically.
+     * @param groupId Maven group
+     * @param artifactId Maven artifact
+     * @param version version
+     */
+    public ContainerLabel(String groupId, String artifactId, String version) {
+        this(groupId, artifactId, version, UUID.randomUUID().toString());
+    }
+
+    /**
+     * Construct from maven coordinates and run ID. If the runId is <code>null</code> this label
+     * will.
+     *
+     * @param groupId Maven group
+     * @param artifactId Maven artifact
+     * @param version version
+     * @param runId a run id or <code>null</code>.
+     */
+    public ContainerLabel(String groupId, String artifactId, String version, String runId) {
+        mavenCoordinates = groupId + ":" + artifactId + ":" + version;
+        this.runId = runId;
+    }
+
+    /**
+     * Get this label in string representation
+     * @return this label as string
+     */
+    public String toString() {
+        return mavenCoordinates + (runId != null ? ":" + runId : "");
+    }
+
+    /**
+     * Check whether this label matches another. For a match the maven coordinates must fit and if this
+     * runId is set, the runId must match, too.
+     *
+     * @param other label to match
+     * @return true for a match
+     */
+    public boolean matches(ContainerLabel other) {
+        return other.mavenCoordinates.equals(mavenCoordinates) &&
+               (runId == null || runId.equals(other.runId));
+    }
+
+    /**
+     * Get the label name
+     *
+     * @return the label name to use to mark a container belonging to this build
+     */
+    public String getName() {
+        return "docker.maven.plugin.container";
+    }
+}

--- a/src/main/java/org/jolokia/docker/maven/util/PomLabel.java
+++ b/src/main/java/org/jolokia/docker/maven/util/PomLabel.java
@@ -1,4 +1,5 @@
-package org.jolokia.docker.maven.util;/*
+package org.jolokia.docker.maven.util;
+/*
  * 
  * Copyright 2014 Roland Huss
  *
@@ -25,12 +26,11 @@ import java.util.UUID;
  */
 public class PomLabel {
 
-    private String mavenCoordinates;
-    private String runId;
-
-
     // Environment variable used to label containers
     public static final String CONTAINER_LABEL_NAME = "docker.maven.plugin.container";
+    
+    private String mavenCoordinates;
+    private String runId;
 
     /**
      * Construct from a given label
@@ -88,15 +88,26 @@ public class PomLabel {
         return mavenCoordinates + (runId != null ? ":" + runId : "");
     }
 
+    public boolean matches(PomLabel other) {
+        return matches(other, true);
+    }
+    
     /**
-     * Check whether this label matches another. For a match the maven coordinates must fit and if this
-     * runId is set, the runId must match, too.
+     * Check whether this label matches another.
+     * <p>
+     * To match, the maven coordinates must be equal and if <code>incRunId</code> is <code>true</code>, the <code>runId</code> must also
+     * match.
+     * </p>
      *
      * @param other label to match
+     * @param incRunId <code>true<code> if the <code>runId</code> should be considered during the match, <code>false<code> otherwise.
      * @return true for a match
      */
-    public boolean matches(PomLabel other) {
-        return other.mavenCoordinates.equals(mavenCoordinates) &&
-               (runId == null || runId.equals(other.runId));
+    public boolean matches(PomLabel other, boolean incRunId) {
+        boolean matches = other.mavenCoordinates.equals(mavenCoordinates);
+        if (incRunId) {
+            matches = matches && (runId == null || runId.equals(other.runId));
+        }
+        return matches;
     }
 }

--- a/src/main/java/org/jolokia/docker/maven/util/PomLabel.java
+++ b/src/main/java/org/jolokia/docker/maven/util/PomLabel.java
@@ -23,7 +23,7 @@ import java.util.UUID;
  * @author roland
  * @since 31/03/15
  */
-public class ContainerLabel {
+public class PomLabel {
 
     private String mavenCoordinates;
     private String runId;
@@ -37,7 +37,7 @@ public class ContainerLabel {
      *
      * @param label label as stored with the container
      */
-    public ContainerLabel(String label) {
+    public PomLabel(String label) {
         String[] parts = label.split(":");
         if (parts.length != 4 && parts.length != 3) {
             throw new IllegalArgumentException("Label '" + label +
@@ -53,7 +53,7 @@ public class ContainerLabel {
      * @param artifactId Maven artifact
      * @param version version
      */
-    public ContainerLabel(String groupId, String artifactId, String version) {
+    public PomLabel(String groupId, String artifactId, String version) {
         this(groupId, artifactId, version, UUID.randomUUID().toString());
     }
 
@@ -66,16 +66,25 @@ public class ContainerLabel {
      * @param version version
      * @param runId a run id or <code>null</code>.
      */
-    public ContainerLabel(String groupId, String artifactId, String version, String runId) {
+    public PomLabel(String groupId, String artifactId, String version, String runId) {
         mavenCoordinates = groupId + ":" + artifactId + ":" + version;
         this.runId = runId;
+    }
+
+    /**
+     * Get the label name
+     *
+     * @return the label name to use to mark a container belonging to this build
+     */
+    public String getKey() {
+        return "docker.maven.plugin.container";
     }
 
     /**
      * Get this label in string representation
      * @return this label as string
      */
-    public String toString() {
+    public String getValue() {
         return mavenCoordinates + (runId != null ? ":" + runId : "");
     }
 
@@ -86,17 +95,8 @@ public class ContainerLabel {
      * @param other label to match
      * @return true for a match
      */
-    public boolean matches(ContainerLabel other) {
+    public boolean matches(PomLabel other) {
         return other.mavenCoordinates.equals(mavenCoordinates) &&
                (runId == null || runId.equals(other.runId));
-    }
-
-    /**
-     * Get the label name
-     *
-     * @return the label name to use to mark a container belonging to this build
-     */
-    public String getName() {
-        return "docker.maven.plugin.container";
     }
 }

--- a/src/test/java/org/jolokia/docker/maven/model/ContainerDetailsTest.java
+++ b/src/test/java/org/jolokia/docker/maven/model/ContainerDetailsTest.java
@@ -22,7 +22,7 @@ public class ContainerDetailsTest {
     public void testContaierWithMappedPorts() {
         givenAContainerWithMappedPorts();
         whenCreateContainer();
-        thenMapSizeIs(2);
+        thenPortBindingSizeIs(2);
         thenMapContainsSpecAndBinding("80/tcp", 32771, "0.0.0.0");
         thenMapContainsSpecAndBinding("52/udp", 32772, "1.2.3.4");
     }
@@ -31,7 +31,7 @@ public class ContainerDetailsTest {
     public void testContaierWithPorts() {
         givenAContaierWithPorts();
         whenCreateContainer();
-        thenMapSizeIs(2);
+        thenPortBindingSizeIs(2);
         thenMapContainsPortSpecOnly("80/tcp");
         thenMapContainsPortSpecOnly("52/udp");
     }
@@ -40,16 +40,37 @@ public class ContainerDetailsTest {
     public void testContainerWithoutPorts() {
         givenAContainerWithoutPorts();
         whenCreateContainer();
-        thenMapSizeIs(0);
+        thenPortBindingSizeIs(0);
     }
 
+    public void testContainerWithLabels() {
+        givenAContainerWithLabels();
+        whenCreateContainer();
+        thenLabelsSizeIs(2);
+        thenLabelsContains("key1", "value1");
+        thenLabelsContains("key2", "value2");
+    }
+    
+    private void thenLabelsContains(String key, String value) {
+        assertTrue(container.getLabels().containsKey(key));
+        assertEquals(value, container.getLabels().get(key));
+    }
+    
+    private void givenAContainerWithLabels() {
+        JSONObject labels = new JSONObject();
+        labels.put("key1", "value1");
+        labels.put("key2", "value2");
+        
+        json.put(ContainerDetails.LABELS, labels);
+    }
+    
     @Test
     public void testCreateContainer() throws Exception {
         givenContainerData();
         whenCreateContainer();
         thenValidateContainer();
     }
-
+    
     private JSONArray createHostIpAndPort(int port, String ip) {
         JSONObject object = new JSONObject();
         
@@ -112,7 +133,11 @@ public class ContainerDetailsTest {
         assertEquals(port, container.getPortBindings().get(key).getHostPort().intValue());
     }
 
-    private void thenMapSizeIs(int size) {
+    private void thenLabelsSizeIs(int size) {
+        assertEquals(size, container.getLabels().size());   
+    }
+    
+    private void thenPortBindingSizeIs(int size) {
         assertEquals(size, container.getPortBindings().size());
     }
 

--- a/src/test/java/org/jolokia/docker/maven/model/ContainerListElementTest.java
+++ b/src/test/java/org/jolokia/docker/maven/model/ContainerListElementTest.java
@@ -24,7 +24,7 @@ public class ContainerListElementTest {
     public void testContaierWithMappedPorts() {
         givenAContainerWithMappedPorts();
         whenCreateContainer();
-        thenMapSizeIs(2);
+        thenPortBindingSizeIs(2);
         thenMapContainsSpecAndBinding("80/tcp", 32771, "0.0.0.0");
         thenMapContainsSpecAndBinding("52/udp", 32772, "1.2.3.4");
     }
@@ -33,16 +33,32 @@ public class ContainerListElementTest {
     public void testContaierWithPorts() {
         givenAContaierWithPorts();
         whenCreateContainer();
-        thenMapSizeIs(2);
+        thenPortBindingSizeIs(2);
         thenMapContainsPortSpecOnly("80/tcp");
         thenMapContainsPortSpecOnly("52/udp");
+    }
+    
+    @Test
+    public void testContainerWithLabels() {
+        givenAContainerWithLabels();
+        whenCreateContainer();
+        thenLabelsSizeIs(2);
+        thenLabelsContains("key1", "value1");
+        thenLabelsContains("key2", "value2");
+    }
+    
+    @Test
+    public void testContainerWithoutLabels() {
+        givenContainerData();
+        whenCreateContainer();
+        thenLabelsSizeIs(0);
     }
     
     @Test
     public void testContainerWithoutPorts() {
         givenAContainerWithoutPorts();
         whenCreateContainer();
-        thenMapSizeIs(0);
+        thenPortBindingSizeIs(0);
     }
     
     @Test
@@ -73,6 +89,15 @@ public class ContainerListElementTest {
         json.append(ContainersListElement.PORTS, createPortData(80, "tcp"));
         json.append(ContainersListElement.PORTS, createPortData(52, "udp"));
     }
+
+    
+    private void givenAContainerWithLabels() {
+        JSONObject labels = new JSONObject();
+        labels.put("key1", "value1");
+        labels.put("key2", "value2");
+        
+        json.put(ContainerDetails.LABELS, labels);
+    }
     
     private void givenAContainerWithMappedPorts() {
         givenAContaierWithPorts();
@@ -98,11 +123,20 @@ public class ContainerListElementTest {
         json.put(ContainersListElement.PORTS, new JSONArray());
     }
 
+    private void thenLabelsContains(String key, String value) {
+        assertTrue(container.getLabels().containsKey(key));
+        assertEquals(value, container.getLabels().get(key));
+    }
+
+    private void thenLabelsSizeIs(int size) {
+        assertEquals(size, container.getLabels().size());
+    }
+    
     private void thenMapContainsPortSpecOnly(String key) {
         assertTrue(container.getPortBindings().containsKey(key));
         assertNull(container.getPortBindings().get(key));
     }
-
+    
     private void thenMapContainsSpecAndBinding(String key, int port, String ip) {
         assertTrue(container.getPortBindings().containsKey(key));
         assertNotNull(container.getPortBindings().get(key));
@@ -111,7 +145,7 @@ public class ContainerListElementTest {
         assertEquals(port, container.getPortBindings().get(key).getHostPort().intValue());
     }
     
-    private void thenMapSizeIs(int size) {
+    private void thenPortBindingSizeIs(int size) {
         assertEquals(size, container.getPortBindings().size());
     }
 

--- a/src/test/java/org/jolokia/docker/maven/service/RunServiceTest.java
+++ b/src/test/java/org/jolokia/docker/maven/service/RunServiceTest.java
@@ -1,24 +1,12 @@
 package org.jolokia.docker.maven.service;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
+import java.util.*;
 
 import mockit.*;
 import org.apache.commons.io.IOUtils;
-import org.jolokia.docker.maven.access.ContainerCreateConfig;
-import org.jolokia.docker.maven.access.ContainerHostConfig;
-import org.jolokia.docker.maven.access.DockerAccess;
-import org.jolokia.docker.maven.access.DockerAccessException;
-import org.jolokia.docker.maven.access.PortMapping;
+import org.jolokia.docker.maven.access.*;
 import org.jolokia.docker.maven.config.*;
 import org.jolokia.docker.maven.log.LogOutputSpec;
 import org.jolokia.docker.maven.log.LogOutputSpecFactory;
@@ -26,6 +14,8 @@ import org.jolokia.docker.maven.util.Logger;
 import org.junit.Before;
 import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
+
+import static org.junit.Assert.*;
 
 /**
  * This test need to be refactored. In fact, testing Mojos must be setup correctly at all. Blame on me that there are so
@@ -300,7 +290,7 @@ public class RunServiceTest {
     private void whenCreateContainerConfig(String imageName) throws DockerAccessException {
         PortMapping portMapping = runService.getPortMapping(runConfig, properties);
 
-        containerConfig = runService.createContainerConfig(imageName, runConfig, portMapping, properties);
+        containerConfig = runService.createContainerConfig(imageName, runConfig, portMapping, null, properties);
         startConfig = runService.createContainerHostConfig(runConfig, portMapping);
     }
 

--- a/src/test/java/org/jolokia/docker/maven/util/ContainerLabelTest.java
+++ b/src/test/java/org/jolokia/docker/maven/util/ContainerLabelTest.java
@@ -1,0 +1,87 @@
+package org.jolokia.docker.maven.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+/*
+ * 
+ * Copyright 2014 Roland Huss
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @author roland
+ * @since 31/03/15
+ */
+public class ContainerLabelTest {
+
+    String g = "org.jolokia";
+    String a = "demo";
+    String v = "0.0.1";
+    String coord = g + ":" + a + ":" + v;
+
+    @Test
+    public void simple() throws Exception {
+        ContainerLabel label = new ContainerLabel(g,a,v);
+        assertTrue(label.toString().startsWith(coord));
+        assertTrue(label.toString().length() > coord.length());
+    }
+
+    @Test
+    public void withNullRunId() {
+        ContainerLabel label = new ContainerLabel(g,a,v,null);
+        assertEquals(label.toString(), coord);
+    }
+
+    @Test
+    public void withRunId() {
+        ContainerLabel label = new ContainerLabel(g,a,v,"blub");
+        assertEquals(label.toString(),coord + ":blub");
+    }
+
+    @Test
+    public void matchesAll() throws Exception {
+        ContainerLabel label = new ContainerLabel(g, a, v,null);
+        assertTrue(label.matches(new ContainerLabel(g, a, v)));
+    }
+
+    @Test
+    public void dontMatch() {
+        ContainerLabel label = new ContainerLabel(g, a, v);
+        assertFalse(label.matches(new ContainerLabel(g, a, v)));
+    }
+
+    @Test
+    public void match() {
+        ContainerLabel label = new ContainerLabel(g, a, v, "bla");
+        assertTrue(label.matches(new ContainerLabel(g, a, v, "bla")));
+    }
+
+    @Test
+    public void parse() {
+        ContainerLabel label = new ContainerLabel(coord);
+        assertEquals(coord, label.toString());
+    }
+
+    @Test
+    public void parse2() {
+        ContainerLabel label = new ContainerLabel(coord + ":blub");
+        assertEquals(coord + ":blub",label.toString());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void invalid() {
+        new ContainerLabel("bla");
+    }
+}

--- a/src/test/java/org/jolokia/docker/maven/util/PomLabelTest.java
+++ b/src/test/java/org/jolokia/docker/maven/util/PomLabelTest.java
@@ -63,6 +63,12 @@ public class PomLabelTest {
     }
 
     @Test
+    public void dontIncludeRunId() {
+        PomLabel label = new PomLabel(g, a, v, "bla");
+        assertTrue(label.matches(new PomLabel(g, a, v, "foo"), false));
+    }
+    
+    @Test
     public void match() {
         PomLabel label = new PomLabel(g, a, v, "bla");
         assertTrue(label.matches(new PomLabel(g, a, v, "bla")));

--- a/src/test/java/org/jolokia/docker/maven/util/PomLabelTest.java
+++ b/src/test/java/org/jolokia/docker/maven/util/PomLabelTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.*;
  * @author roland
  * @since 31/03/15
  */
-public class ContainerLabelTest {
+public class PomLabelTest {
 
     String g = "org.jolokia";
     String a = "demo";
@@ -33,55 +33,55 @@ public class ContainerLabelTest {
 
     @Test
     public void simple() throws Exception {
-        ContainerLabel label = new ContainerLabel(g,a,v);
-        assertTrue(label.toString().startsWith(coord));
-        assertTrue(label.toString().length() > coord.length());
+        PomLabel label = new PomLabel(g,a,v);
+        assertTrue(label.getValue().startsWith(coord));
+        assertTrue(label.getValue().length() > coord.length());
     }
 
     @Test
     public void withNullRunId() {
-        ContainerLabel label = new ContainerLabel(g,a,v,null);
-        assertEquals(label.toString(), coord);
+        PomLabel label = new PomLabel(g,a,v,null);
+        assertEquals(label.getValue(), coord);
     }
 
     @Test
     public void withRunId() {
-        ContainerLabel label = new ContainerLabel(g,a,v,"blub");
-        assertEquals(label.toString(),coord + ":blub");
+        PomLabel label = new PomLabel(g,a,v,"blub");
+        assertEquals(label.getValue(),coord + ":blub");
     }
 
     @Test
     public void matchesAll() throws Exception {
-        ContainerLabel label = new ContainerLabel(g, a, v,null);
-        assertTrue(label.matches(new ContainerLabel(g, a, v)));
+        PomLabel label = new PomLabel(g, a, v,null);
+        assertTrue(label.matches(new PomLabel(g, a, v)));
     }
 
     @Test
     public void dontMatch() {
-        ContainerLabel label = new ContainerLabel(g, a, v);
-        assertFalse(label.matches(new ContainerLabel(g, a, v)));
+        PomLabel label = new PomLabel(g, a, v);
+        assertFalse(label.matches(new PomLabel(g, a, v)));
     }
 
     @Test
     public void match() {
-        ContainerLabel label = new ContainerLabel(g, a, v, "bla");
-        assertTrue(label.matches(new ContainerLabel(g, a, v, "bla")));
+        PomLabel label = new PomLabel(g, a, v, "bla");
+        assertTrue(label.matches(new PomLabel(g, a, v, "bla")));
     }
 
     @Test
     public void parse() {
-        ContainerLabel label = new ContainerLabel(coord);
-        assertEquals(coord, label.toString());
+        PomLabel label = new PomLabel(coord);
+        assertEquals(coord, label.getValue());
     }
 
     @Test
     public void parse2() {
-        ContainerLabel label = new ContainerLabel(coord + ":blub");
-        assertEquals(coord + ":blub",label.toString());
+        PomLabel label = new PomLabel(coord + ":blub");
+        assertEquals(coord + ":blub",label.getValue());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void invalid() {
-        new ContainerLabel("bla");
+        new PomLabel("bla");
     }
 }

--- a/src/test/resources/docker/containerCreateConfigAll.json
+++ b/src/test/resources/docker/containerCreateConfigAll.json
@@ -1,4 +1,5 @@
 {
+  "Env": ["foo=bar"],
   "User": "user",
   "Entrypoint": [ "entrypoint" ],
   "Memory": 1,

--- a/src/test/resources/docker/containerCreateConfigAll.json
+++ b/src/test/resources/docker/containerCreateConfigAll.json
@@ -1,5 +1,4 @@
 {
-  "Env": ["foo=bar"],
   "User": "user",
   "Entrypoint": [ "entrypoint" ],
   "Memory": 1,


### PR DESCRIPTION
it's a glorious day! :)

couple of things...

1) i'm not sure how you intended for the `runId` to work, but i had to add an option to ignore it when calling `docker:stop` from a standalone context. i had already made a change (i forget when) that fixed this for containers that were started/stopped during the same build run. i didn't remove any of that code, i just added an option to ignore the run id.

2). i bumped things to `0.14-0-SNAPSHOT` b/c this required the docker api to be rev-ed. `v1.18` is still part of docker 1.6, so perhaps it can stay at `0.13.7-SNAPSHOT`.

3) there is still the option to make the plugin work like it did before using `docker.sledgehammer` (and i really hope we can keep that name)

4) i did not bother to account for containers that may have been created using an older version of the plugin and have upgraded to whatever version this goes out as. it didn't seem worth the extra work when the containers can be stopped using `-Ddocker.sledgehammer` and then re-created w/ `docker:start` and have the labels applied.